### PR TITLE
build: fix CI (linting of migration file)

### DIFF
--- a/alembic/versions/20231123_0828_5acb37b190cc_add_prices_category_tag_field.py
+++ b/alembic/versions/20231123_0828_5acb37b190cc_add_prices_category_tag_field.py
@@ -7,9 +7,9 @@ Create Date: 2023-11-23 08:28:39.136672
 """
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "5acb37b190cc"


### PR DESCRIPTION
### What

run `pre-commit run --all-files` and fix the migration file that was making the CI fail