### PR TITLE
feat: add support for cookie authentication

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -9,12 +9,14 @@ from fastapi import (
     Depends,
     FastAPI,
     HTTPException,
+    Query,
     Request,
+    Response,
     UploadFile,
     status,
 )
 from fastapi.responses import HTMLResponse, PlainTextResponse
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi_filter import FilterDepends
@@ -25,6 +27,7 @@ from openfoodfacts.utils import get_logger
 from sqlalchemy.orm import Session
 
 from app import crud, schemas, tasks
+from app.auth import OAuth2PasswordBearerOrAuthCookie
 from app.config import settings
 from app.db import session
 from app.utils import init_sentry
@@ -63,7 +66,7 @@ def get_db():
 
 # Authentication helpers
 # ------------------------------------------------------------------------------
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth")
+oauth2_scheme = OAuth2PasswordBearerOrAuthCookie(tokenUrl="auth")
 
 
 def create_token(user_id: str):
@@ -99,16 +102,30 @@ def main_page(request: Request):
 @app.post("/auth")
 def authentication(
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    response: Response,
+    set_cookie: Annotated[
+        bool,
+        Query(
+            description="if set to 1, the token is also set as a cookie "
+            "named 'session' in the response. This parameter must be passed "
+            "as a query parameter, e.g.: /auth?set_cookie=1"
+        ),
+    ] = False,
     db: Session = Depends(get_db),
 ):
     """
-    Authentication: provide username/password and get a bearer token in return
+    Authentication: provide username/password and get a bearer token in return.
 
     - **username**: Open Food Facts user_id (not email)
     - **password**: user password (clear text, but HTTPS encrypted)
 
-    a **token** is returned
-    to be used in requests with usual "Authorization: bearer token" header
+    A **token** is returned. If the **set_cookie** parameter is set to 1,
+    the token is also set as a cookie named "session" in the response.
+
+    To authenticate, you can either:
+    - use the **Authorization** header with the **Bearer** scheme,
+      e.g.: "Authorization: bearer token"
+    - use the **session** cookie, e.g.: "Cookie: session=token"
     """
     if "oauth2_server_url" not in settings.model_dump():
         raise HTTPException(
@@ -122,6 +139,14 @@ def authentication(
         token = create_token(form_data.username)
         user = schemas.UserBase(user_id=form_data.username, token=token)
         crud.create_user(db, user=user)
+
+        # set the cookie if requested
+        if set_cookie:
+            # Don't add httponly=True or secure=True as it's still in
+            # development phase, but it should be added once the front-end
+            # is ready
+            response.set_cookie(key="session", value=token)
+
         return {"access_token": token, "token_type": "bearer"}
     elif r.status_code == 403:
         time.sleep(2)  # prevents brute-force

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,53 @@
+from typing import Any, Optional, cast
+
+from fastapi.exceptions import HTTPException
+from fastapi.openapi.models import OAuthFlows as OAuthFlowsModel
+from fastapi.security import OAuth2
+from fastapi.security.utils import get_authorization_scheme_param
+from starlette.requests import Request
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+
+# This class is derived from FastAPI's OAuth2PasswordBearer class,
+# but adds support for cookie sessions.
+class OAuth2PasswordBearerOrAuthCookie(OAuth2):
+    def __init__(
+        self,
+        tokenUrl: str,
+        scheme_name: str | None = None,
+        scopes: dict[str, str] | None = None,
+        description: str | None = None,
+        auto_error: bool = True,
+    ):
+        if not scopes:
+            scopes = {}
+        flows = OAuthFlowsModel(
+            password=cast(Any, {"tokenUrl": tokenUrl, "scopes": scopes})
+        )
+        super().__init__(
+            flows=flows,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization = request.headers.get("Authorization")
+        session_cookie = request.cookies.get("session")
+        scheme, param = get_authorization_scheme_param(authorization)
+
+        # If a session cookie is present, use that instead of the
+        # Authorization header.
+        if session_cookie:
+            return session_cookie
+
+        if not authorization or scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail="Not authenticated",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            else:
+                return None
+        return param


### PR DESCRIPTION
By providing `set_cookie=1`, the API sets an auth cookie on the device.