### PR TITLE
feat: add frontend app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,6 @@ dmypy.json
 
 # Project specific
 
-data/images
+static/app
+static/img/*/*
 gh_pages

--- a/app/api.py
+++ b/app/api.py
@@ -10,15 +10,12 @@ from fastapi import (
     FastAPI,
     HTTPException,
     Query,
-    Request,
     Response,
     UploadFile,
     status,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.security import OAuth2PasswordRequestForm
-from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi_filter import FilterDepends
 from fastapi_pagination import Page, add_pagination
@@ -50,6 +47,8 @@ app = FastAPI(
         "name": " AGPL-3.0",
         "url": "https://www.gnu.org/licenses/agpl-3.0.en.html",
     },
+    docs_url="/api/docs",
+    openapi_url="/api/openapi.json",
 )
 
 app.add_middleware(
@@ -102,12 +101,6 @@ def get_current_user(
 
 # Routes
 # ------------------------------------------------------------------------------
-@app.get("/", response_class=HTMLResponse)
-def main_page(request: Request):
-    return templates.TemplateResponse(
-        "index.html",
-        {"request": request},
-    )
 
 
 @app.post("/api/v1/auth")
@@ -303,10 +296,4 @@ def status_endpoint():
     return {"status": "running"}
 
 
-@app.get("/robots.txt", response_class=PlainTextResponse)
-def robots_txt():
-    return """User-agent: *\nDisallow: /"""
-
-
 add_pagination(app)
-app.mount("/images", StaticFiles(directory=str(settings.images_dir)), name="images")

--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,7 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 ROOT_DIR = Path(__file__).parent.parent
-DATA_DIR = ROOT_DIR / "data"
+STATIC_DIR = ROOT_DIR / "static"
 
 
 class LoggingLevel(Enum):
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     oauth2_server_url: str | None = None
     sentry_dns: str | None = None
     log_level: LoggingLevel = LoggingLevel.INFO
-    images_dir: Path = DATA_DIR / "images"
+    images_dir: Path = STATIC_DIR / "img"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -182,7 +182,7 @@ class ProofCreate(BaseModel):
 
     file_path: str
     mimetype: str
-    type: ProofTypeEnum
+    type: ProofTypeEnum | None = None
 
 
 class ProofBase(ProofCreate):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,8 @@ x-api-common: &api-common
 services:
   api:
     <<: *api-common
-    ports:
-      - "${API_PORT}:8000"
     volumes:
-      - ./data:/opt/open-prices/data
+      - ./static:/opt/open-prices/static
 
   postgres:
     restart: $RESTART_POLICY
@@ -38,6 +36,16 @@ services:
     shm_size: 1g
     ports:
       - "${POSTGRES_EXPOSE:-127.0.0.1:5432}:5432"
+
+  nginx: 
+    image: nginx:1.25-alpine
+    volumes:
+      # Mount the nginx configuration file
+      - ./nginx.conf:/etc/nginx/nginx.conf
+      # Mount the static files
+      - ./static:/var/static
+    ports:
+      - ${API_PORT}:80
 
 volumes:
   postgres-data:

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -17,6 +17,8 @@ x-api-base: &api-base
     - ./README.md:/opt/open-prices/README.md
     - ./docs:/opt/open-prices/docs
     - ./gh_pages:/opt/open-prices/gh_pages
+    # Make migrations available so that we can run them easily
+    - ./alembic:/opt/open-prices/alembic
 
 services:
   api:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,56 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    resolver 127.0.0.11 valid=5s;
+
+    server {
+        # There is a single server block for all requests
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        root /var/static;
+        index index.html;
+
+        location /api/ {
+            proxy_pass http://api:8000$request_uri;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_read_timeout 90;
+            client_max_body_size 50M;
+        }
+
+        # Make vue.js app available under /app
+        location /app/ {
+            alias /var/static/app/;
+            try_files $uri $uri/ /app/index.html;
+        }
+    }
+}

--- a/static/index.html
+++ b/static/index.html
@@ -42,7 +42,7 @@
                             does Open Prices work?</h2>
                         <p>We are crowdsourcing an open-source dataset of food prices.
                             Prices can be added by retailers or hackers through <a
-                                href="https://prices.openfoodfacts.org/docs">our API</a>.
+                                href="https://prices.openfoodfacts.org/api/docs">our API</a>.
                             A web and mobile app is in the works to make it easier for
                             people to add prices.</p>
                         <p>Open Prices is not only meant to store individual prices, but also
@@ -109,7 +109,7 @@
                         <p>You can contribute by adding prices to the dataset. You
                             can
                             do so by using <a
-                                href="https://prices.openfoodfacts.org/docs">our API</a>
+                                href="https://prices.openfoodfacts.org/api/docs">our API</a>
                             or by using our web or mobile app (coming soon). You
                             need an
                             Open Food Facts account to contribute. If you don’t have
@@ -204,7 +204,7 @@
                     </div>
                     <div class="small-12 medium-8 columns">
                         <p>You can contribute prices by using <a
-                                href="https://prices.openfoodfacts.org/docs">our API</a>.
+                                href="https://prices.openfoodfacts.org/api/docs">our API</a>.
                             If you want to contribute prices at scale, please get in
                             touch with us at <a
                                 href="mailto:contact@openfoodfacts.org">contact@openfoodfacts.org</a>.</p>

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,11 +73,6 @@ def location(db=override_get_db()):
 
 # Tests
 # ------------------------------------------------------------------------------
-def test_hello():
-    response = client.get("/")
-    assert response.status_code == 200
-
-
 def test_create_price(user, db=override_get_db()):
     # without authentication
     response = client.post(


### PR DESCRIPTION
The front-end (the content in the dist folder) must be deployed under /static/app

- use an nginx server as a reverse-proxy
- serve static assets (images, robots.txt, index.html) through nginx
- host OpenAPI docs under /api/docs (instead of /docs)