### PR TITLE
feat: add relationship objects in response of GET /prices

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -164,7 +164,7 @@ def authentication(
     )
 
 
-@app.get("/api/v1/prices", response_model=Page[schemas.PriceBase], tags=["Prices"])
+@app.get("/api/v1/prices", response_model=Page[schemas.PriceFull], tags=["Prices"])
 def get_price(
     filters: schemas.PriceFilter = FilterDepends(schemas.PriceFilter),
     db: Session = Depends(get_db),

--- a/app/crud.py
+++ b/app/crud.py
@@ -4,7 +4,7 @@ from mimetypes import guess_extension
 
 from fastapi import UploadFile
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.sql import func
 
 from app import config
@@ -105,9 +105,15 @@ def update_product(db: Session, product: ProductBase, update_dict: dict):
 
 # Prices
 # ------------------------------------------------------------------------------
-def get_prices_query(filters: PriceFilter | None = None):
+def get_prices_query(
+    with_join_product=True, with_join_location=True, filters: PriceFilter | None = None
+):
     """Useful for pagination."""
     query = select(Price)
+    if with_join_product:
+        query = query.options(joinedload(Price.product))
+    if with_join_location:
+        query = query.options(joinedload(Price.location))
     if filters:
         query = filters.filter(query)
     return query

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -184,6 +184,11 @@ class PriceBase(PriceCreate):
     created: datetime.datetime
 
 
+class PriceFull(PriceBase):
+    product: ProductBase | None
+    location: LocationBase | None
+
+
 class ProofCreate(BaseModel):
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -234,6 +234,8 @@ def test_get_prices():
     assert len(response.json()["items"]) == 3
     for price_field in ["product_id", "location_id", "proof_id"]:
         assert price_field in response.json()["items"][0]
+    for price_relationship in ["product", "location"]:
+        assert price_relationship in response.json()["items"][0]
 
 
 def test_get_prices_pagination():


### PR DESCRIPTION
### What

Enrich `price` objects with `product` & `location` objects.
Return `null` if no data.

### Screenshot

|Before|After|
|---|---|
|![image](https://github.com/openfoodfacts/open-prices/assets/7147385/ce89dccf-abdc-422e-a198-8e61c3f1d4de)|![Screenshot from 2023-12-18 15-48-49](https://github.com/openfoodfacts/open-prices/assets/7147385/61e32637-99f2-41a3-8cff-af2afcd549bd)|

