### PR TITLE
feat: ask for proof type when creating

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -8,6 +8,7 @@ from fastapi import (
     BackgroundTasks,
     Depends,
     FastAPI,
+    Form,
     HTTPException,
     Query,
     Response,
@@ -28,6 +29,7 @@ from app import crud, schemas, tasks
 from app.auth import OAuth2PasswordBearerOrAuthCookie
 from app.config import settings
 from app.db import session
+from app.enums import ProofTypeEnum
 from app.utils import init_sentry
 
 logger = get_logger(level=settings.log_level.to_int())
@@ -242,6 +244,7 @@ def create_price(
 )
 def upload_proof(
     file: UploadFile,
+    type: ProofTypeEnum = Form(),
     current_user: schemas.UserBase = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -254,7 +257,7 @@ def upload_proof(
     This endpoint requires authentication.
     """
     file_path, mimetype = crud.create_proof_file(file)
-    db_proof = crud.create_proof(db, file_path, mimetype, user=current_user)
+    db_proof = crud.create_proof(db, file_path, mimetype, type=type, user=current_user)
     return db_proof
 
 

--- a/app/crud.py
+++ b/app/crud.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.sql import func
 
 from app import config
-from app.enums import LocationOSMEnum
+from app.enums import LocationOSMEnum, ProofTypeEnum
 from app.models import Location, Price, Product, Proof, User
 from app.schemas import (
     LocationBase,
@@ -156,7 +156,9 @@ def get_user_proofs(db: Session, user: UserBase):
     return db.query(Proof).filter(Proof.owner == user.user_id).all()
 
 
-def create_proof(db: Session, file_path: str, mimetype: str, user: UserBase):
+def create_proof(
+    db: Session, file_path: str, mimetype: str, type: ProofTypeEnum, user: UserBase
+):
     """Create a proof in the database.
 
     :param db: the database session
@@ -165,7 +167,9 @@ def create_proof(db: Session, file_path: str, mimetype: str, user: UserBase):
     :param user: the user who uploaded the file
     :return: the created proof
     """
-    db_proof = Proof(file_path=file_path, mimetype=mimetype, owner=user.user_id)
+    db_proof = Proof(
+        file_path=file_path, mimetype=mimetype, type=type, owner=user.user_id
+    )
     db.add(db_proof)
     db.commit()
     db.refresh(db_proof)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -189,16 +189,18 @@ class PriceFull(PriceBase):
     location: LocationBase | None
 
 
-class ProofCreate(BaseModel):
+# class ProofCreate(BaseModel):
+#     file: UploadFile
+#     type: ProofTypeEnum
+
+
+class ProofBase(BaseModel):
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
 
+    id: int
     file_path: str
     mimetype: str
     type: ProofTypeEnum | None = None
-
-
-class ProofBase(ProofCreate):
-    id: int
     owner: str
     created: datetime.datetime
 


### PR DESCRIPTION
### What

Currently we create proofs without defining their type.

With this PR the `type` info is now mandatory to create a proof.