### PR TITLE
docs: add a link to the frontend repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A REST API designed to interact with the Open Food Facts _Open Prices_ database.
 
+If you are looking for the frontend of Open Prices, [look here](https://github.com/openfoodfacts/open-prices-frontend)
+
 ## Dependencies
 
 * Python 3.10


### PR DESCRIPTION
### What
- doc: I've looked too many times for the frontend URL