### PR TITLE
feat: add price filters on category_tag, labels_tags & origins_tags

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -267,6 +267,7 @@ class ProofBase(BaseModel):
 class PriceFilter(Filter):
     product_code: Optional[str] | None = None
     product_id: Optional[int] | None = None
+    category_tag: Optional[str] | None = None
     location_osm_id: Optional[int] | None = None
     location_osm_type: Optional[LocationOSMEnum] | None = None
     location_id: Optional[int] | None = None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -268,21 +268,24 @@ class PriceFilter(Filter):
     product_code: Optional[str] | None = None
     product_id: Optional[int] | None = None
     category_tag: Optional[str] | None = None
+    labels_tags__like: Optional[str] | None = None
+    origins_tags__like: Optional[str] | None = None
     location_osm_id: Optional[int] | None = None
     location_osm_type: Optional[LocationOSMEnum] | None = None
     location_id: Optional[int] | None = None
     price: Optional[int] | None = None
-    currency: Optional[str] | None = None
     price__gt: Optional[int] | None = None
     price__gte: Optional[int] | None = None
     price__lt: Optional[int] | None = None
     price__lte: Optional[int] | None = None
+    currency: Optional[str] | None = None
     date: Optional[str] | None = None
     date__gt: Optional[str] | None = None
     date__gte: Optional[str] | None = None
     date__lt: Optional[str] | None = None
     date__lte: Optional[str] | None = None
     owner: Optional[str] | None = None
+
     order_by: Optional[list[str]] | None = None
 
     class Constants(Filter.Constants):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -304,7 +304,11 @@ def test_get_prices_filters(db_session, user, clean_prices):
     crud.create_price(
         db_session,
         PRICE_1.model_copy(
-            update={"price": 3.99, "date": datetime.date.fromisoformat("2023-11-01")}
+            update={
+                "price": 3.99,
+                "currency": "USD",
+                "date": datetime.date.fromisoformat("2023-11-01"),
+            }
         ),
         user,
     )
@@ -342,6 +346,10 @@ def test_get_prices_filters(db_session, user, clean_prices):
     assert len(response.json()["items"]) == 1
     # 1 price with price > 5
     response = client.get("/api/v1/prices?price__gt=5")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    # 1 price with currency USD
+    response = client.get("/api/v1/prices?currency=USD")
     assert response.status_code == 200
     assert len(response.json()["items"]) == 1
     # 2 prices with date = 2023-10-31

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -309,21 +309,32 @@ def test_get_prices_filters(db_session, user, clean_prices):
         user,
     )
     crud.create_price(db_session, PRICE_1.model_copy(update={"price": 5.10}), user)
+    crud.create_price(
+        db_session,
+        PRICE_1.model_copy(
+            update={"product_code": None, "category_tag": "en:tomatoes"}
+        ),
+        user,
+    )
 
-    assert len(crud.get_prices(db_session)) == 3
+    assert len(crud.get_prices(db_session)) == 4
 
+    # 3 prices with the same product_code
     response = client.get(f"/api/v1/prices?product_code={PRICE_1.product_code}")
     assert response.status_code == 200
-    # 3 prices with the same product_code
     assert len(response.json()["items"]) == 3
+    # 1 price with a category
+    response = client.get("/api/v1/prices?category_tag=en:tomatoes")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    # 1 price with price > 5
     response = client.get("/api/v1/prices?price__gt=5")
     assert response.status_code == 200
-    # 1 price with price > 5
     assert len(response.json()["items"]) == 1
-    response = client.get("/api/v1/prices?date=2023-10-31")
-    assert response.status_code == 200
     # 2 prices with date = 2023-10-31
-    assert len(response.json()["items"]) == 2
+    response = client.get(f"/api/v1/prices?date={PRICE_1.date}")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 3
 
 
 def test_get_prices_orders(db_session, user, clean_prices):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -312,7 +312,12 @@ def test_get_prices_filters(db_session, user, clean_prices):
     crud.create_price(
         db_session,
         PRICE_1.model_copy(
-            update={"product_code": None, "category_tag": "en:tomatoes"}
+            update={
+                "product_code": None,
+                "category_tag": "en:tomatoes",
+                "labels_tags": ["en:organic"],
+                "origins_tags": ["en:spain"],
+            }
         ),
         user,
     )
@@ -323,8 +328,16 @@ def test_get_prices_filters(db_session, user, clean_prices):
     response = client.get(f"/api/v1/prices?product_code={PRICE_1.product_code}")
     assert response.status_code == 200
     assert len(response.json()["items"]) == 3
-    # 1 price with a category
+    # 1 price with a category_tag
     response = client.get("/api/v1/prices?category_tag=en:tomatoes")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    # 1 price with labels_tags
+    response = client.get("/api/v1/prices?labels_tags__like=en:organic")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    # 1 price with origins_tags
+    response = client.get("/api/v1/prices?origins_tags__like=en:spain")
     assert response.status_code == 200
     assert len(response.json()["items"]) == 1
     # 1 price with price > 5


### PR DESCRIPTION
### What

New price filters on raw product fields : 
- `category_tags`
- `labels_tags__like` (array)
- `origins_tags__like` (array)

Add tests