### PR TITLE
feat(auth): avoid recreating existing user on login

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -106,9 +106,9 @@ def get_current_user(
     :return: the current user
     """
     if token and "__U" in token:
-        current_user = crud.update_user_last_used_field(db, token=token)
-        if current_user:
-            return current_user
+        db_user = crud.get_user_by_token(db, token=token)
+        if db_user:
+            return crud.update_user_last_used_field(db, user=db_user)
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid authentication credentials",
@@ -130,7 +130,9 @@ def get_current_user_optional(
     :return: the current user if authenticated, None otherwise
     """
     if token and "__U" in token:
-        return crud.update_user_last_used_field(db, token=token)
+        db_user = crud.get_user_by_token(db, token=token)
+        if db_user:
+            return crud.update_user_last_used_field(db, user=db_user)
     return None
 
 
@@ -180,7 +182,7 @@ def authentication(
     if r.status_code == 200:
         token = create_token(form_data.username)
         user = schemas.UserBase(user_id=form_data.username, token=token)
-        crud.create_user(db, user=user)
+        db_user, created = crud.get_or_create_user(db, user=user)
 
         # set the cookie if requested
         if set_cookie:

--- a/app/api.py
+++ b/app/api.py
@@ -183,15 +183,14 @@ def authentication(
         token = create_token(form_data.username)
         user = schemas.UserBase(user_id=form_data.username, token=token)
         db_user, created = crud.get_or_create_user(db, user=user)
-
+        user = crud.update_user_last_used_field(db, user=db_user)
         # set the cookie if requested
         if set_cookie:
             # Don't add httponly=True or secure=True as it's still in
             # development phase, but it should be added once the front-end
             # is ready
-            response.set_cookie(key="session", value=token)
-
-        return {"access_token": token, "token_type": "bearer"}
+            response.set_cookie(key="session", value=user.token)
+        return {"access_token": user.token, "token_type": "bearer"}
     elif r.status_code == 403:
         time.sleep(2)  # prevents brute-force
         raise HTTPException(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,6 +144,13 @@ def test_create_price(db_session, user, clean_prices):
         json=jsonable_encoder(PRICE_1),
     )
     assert response.status_code == 401
+    # with wrong authentication
+    response = client.post(
+        "/api/v1/prices",
+        json=jsonable_encoder(PRICE_1),
+        headers={"Authorization": f"Bearer {user.token}X"},
+    )
+    assert response.status_code == 401
     # with authentication
     response = client.post(
         "/api/v1/prices",


### PR DESCRIPTION
### What

Currently on each new login, we would delete any existing user and recreate it + generate a new token.

But it had some big limitations : 
- lose created info
- regenerate a token, so it would not be possible to have a fixed token on multiple devices

Changed to creating a new user only if it doesn't already exist