### PR TITLE
feat: paginate, filter & order proofs

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -339,9 +339,10 @@ def upload_proof(
     return db_proof
 
 
-@app.get("/api/v1/proofs", response_model=list[schemas.ProofFull], tags=["Proofs"])
+@app.get("/api/v1/proofs", response_model=Page[schemas.ProofFull], tags=["Proofs"])
 def get_user_proofs(
     current_user: schemas.UserCreate = Depends(get_current_user),
+    filters: schemas.ProofFilter = FilterDepends(schemas.ProofFilter),
     db: Session = Depends(get_db),
 ):
     """
@@ -349,7 +350,8 @@ def get_user_proofs(
 
     This endpoint requires authentication.
     """
-    return crud.get_user_proofs(db, user=current_user)
+    filters.owner = current_user.user_id
+    return paginate(db, crud.get_proofs_query(filters=filters))
 
 
 # Routes: Products

--- a/app/crud.py
+++ b/app/crud.py
@@ -22,6 +22,7 @@ from app.schemas import (
     ProductCreate,
     ProductFilter,
     ProductFull,
+    ProofFilter,
     UserCreate,
 )
 
@@ -278,6 +279,14 @@ def set_price_location(db: Session, price: PriceFull, location: LocationFull):
 
 # Proofs
 # ------------------------------------------------------------------------------
+def get_proofs_query(filters: ProofFilter | None = None):
+    """Useful for pagination."""
+    query = select(Proof)
+    if filters:
+        query = filters.filter(query)
+    return query
+
+
 def get_proof(db: Session, proof_id: int):
     return db.query(Proof).filter(Proof.id == proof_id).first()
 

--- a/app/crud.py
+++ b/app/crud.py
@@ -288,6 +288,10 @@ def get_proofs_query(filters: ProofFilter | None = None):
     return query
 
 
+def get_proofs(db: Session, filters: ProofFilter | None = None):
+    return db.execute(get_proofs_query(filters=filters)).all()
+
+
 def get_proof(db: Session, proof_id: int):
     return db.query(Proof).filter(Proof.id == proof_id).first()
 

--- a/app/crud.py
+++ b/app/crud.py
@@ -284,15 +284,12 @@ def get_proofs_query(filters: ProofFilter | None = None):
     query = select(Proof)
     if filters:
         query = filters.filter(query)
+        query = filters.sort(query)
     return query
 
 
 def get_proof(db: Session, proof_id: int):
     return db.query(Proof).filter(Proof.id == proof_id).first()
-
-
-def get_user_proofs(db: Session, user: UserCreate):
-    return db.query(Proof).filter(Proof.owner == user.user_id).all()
 
 
 def create_proof(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -371,6 +371,7 @@ class PriceFilter(Filter):
 
 class ProofFilter(Filter):
     owner: Optional[str] | None = None
+    type: Optional[ProofTypeEnum] | None = None
 
     order_by: Optional[list[str]] | None = None
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -372,6 +372,8 @@ class PriceFilter(Filter):
 class ProofFilter(Filter):
     owner: Optional[str] | None = None
 
+    order_by: Optional[list[str]] | None = None
+
     class Constants(Filter.Constants):
         model = Proof
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -14,7 +14,7 @@ from pydantic import (
 )
 
 from app.enums import CurrencyEnum, LocationOSMEnum, PricePerEnum, ProofTypeEnum
-from app.models import Location, Price, Product, User
+from app.models import Location, Price, Product, Proof, User
 
 
 # User
@@ -122,15 +122,15 @@ class ProofFull(BaseModel):
     mimetype: str
     type: ProofTypeEnum | None = None
     owner: str
-    created: datetime.datetime
     is_public: Annotated[
         bool,
         Field(
             default=True,
             description="if true, the proof is public and is included in the API response. "
-            "Set false if only if the proof contains personal information.",
+            "Set false only if the proof contains personal information.",
         ),
     ]
+    created: datetime.datetime
 
 
 # Price
@@ -367,6 +367,13 @@ class PriceFilter(Filter):
 
     class Constants(Filter.Constants):
         model = Price
+
+
+class ProofFilter(Filter):
+    owner: Optional[str] | None = None
+
+    class Constants(Filter.Constants):
+        model = Proof
 
 
 class ProductFilter(Filter):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,6 +44,8 @@ db_session = pytest.fixture(override_get_db, scope="module")
 # ------------------------------------------------------------------------------
 client = TestClient(app)
 
+PAGINATION_KEYS = ["items", "total", "page", "size", "pages"]
+
 USER = UserCreate(user_id="user", token="user__Utoken")
 USER_1 = UserCreate(user_id="user1", token="user1__Utoken1", price_count=0)
 USER_2 = UserCreate(user_id="user2", token="user2__Utoken2", price_count=1)
@@ -169,7 +171,7 @@ def test_get_users(db_session, clean_users):
 def test_get_users_pagination(clean_users):
     response = client.get("/api/v1/users")
     assert response.status_code == 200
-    for key in ["items", "total", "page", "size", "pages"]:
+    for key in PAGINATION_KEYS:
         assert key in response.json()
 
 
@@ -420,7 +422,7 @@ def test_get_prices(db_session, user_session: SessionModel, clean_prices):
 def test_get_prices_pagination():
     response = client.get("/api/v1/prices")
     assert response.status_code == 200
-    for key in ["items", "total", "page", "size", "pages"]:
+    for key in PAGINATION_KEYS:
         assert key in response.json()
 
 
@@ -573,7 +575,12 @@ def test_get_proofs(user_session: SessionModel):
         headers={"Authorization": f"Bearer {user_session.token}"},
     )
     assert response.status_code == 200
-    data = response.json()
+
+    # has pagination
+    for key in PAGINATION_KEYS:
+        assert key in response.json()
+
+    data = response.json()["items"]
     assert len(data) == 2
 
     for item in data:
@@ -612,7 +619,7 @@ def test_get_products(db_session, clean_products):
 def test_get_products_pagination(clean_products):
     response = client.get("/api/v1/products")
     assert response.status_code == 200
-    for key in ["items", "total", "page", "size", "pages"]:
+    for key in PAGINATION_KEYS:
         assert key in response.json()
 
 
@@ -675,7 +682,7 @@ def test_get_locations(db_session, clean_locations):
 def test_get_locations_pagination(clean_locations):
     response = client.get("/api/v1/locations")
     assert response.status_code == 200
-    for key in ["items", "total", "page", "size", "pages"]:
+    for key in PAGINATION_KEYS:
         assert key in response.json()
 
 


### PR DESCRIPTION
### What

Improve the current GET `/proofs` endpoint with : 
- pagination
- filter on `type` (reminder: also a default filter on `owner` as the authenticated user)
- sort

Add tests
