### PR TITLE
perf: enable gzip encoding

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,7 +26,13 @@ http {
 
     keepalive_timeout  65;
 
-    #gzip  on;
+    # gzip
+    gzip on;
+    gzip_min_length 1000;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/html text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml image/x-icon;
 
     resolver 127.0.0.11 valid=5s;
 


### PR DESCRIPTION
### What
Enable gzip encoding to improve web app performance.

Inspired by [these findings](https://github.com/openfoodfacts/open-prices-frontend/issues/88#issuecomment-1941359326).
