### PR TITLE
perf: enable cache for static files in nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,6 +53,13 @@ http {
             client_max_body_size 50M;
         }
 
+        location ~* \.(woff|woff2|otf|jpg|jpeg|png|webp|css|js|ttf|svg|ico)$ {
+            add_header Cache-Control public;
+            add_header Pragma public;
+            add_header Vary Accept-Encoding;
+            expires max;
+        }
+
         # Make vue.js app available under /app
         location /app/ {
             alias /var/static/app/;


### PR DESCRIPTION
### What
Enable cache for static files in nginx.
Add max possible age for them as files built by `vite` have a hash and will be invalidated after each change
