### PR TITLE
feat: add PATCH endpoint to update proof

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -24,9 +24,9 @@ from app.schemas import (
     ProductCreate,
     ProductFilter,
     ProductFull,
+    ProofBasicUpdatableFields,
     ProofFilter,
     ProofFull,
-    ProofBasicUpdatableFields,
     UserCreate,
 )
 
@@ -449,6 +449,7 @@ def increment_proof_price_count(db: Session, proof: ProofFull):
     db.refresh(proof)
     return proof
 
+
 def update_proof(db: Session, proof: Proof, new_values: ProofBasicUpdatableFields):
     new_values_cleaned = new_values.model_dump(exclude_unset=True)
     for key in new_values_cleaned:
@@ -456,6 +457,7 @@ def update_proof(db: Session, proof: Proof, new_values: ProofBasicUpdatableField
     db.commit()
     db.refresh(proof)
     return proof
+
 
 def delete_proof(db: Session, db_proof: ProofFull) -> bool:
     # we delete the image of the proof

--- a/app/crud.py
+++ b/app/crud.py
@@ -26,6 +26,7 @@ from app.schemas import (
     ProductFull,
     ProofFilter,
     ProofFull,
+    ProofBasicUpdatableFields,
     UserCreate,
 )
 
@@ -448,6 +449,13 @@ def increment_proof_price_count(db: Session, proof: ProofFull):
     db.refresh(proof)
     return proof
 
+def update_proof(db: Session, proof: Proof, new_values: ProofBasicUpdatableFields):
+    new_values_cleaned = new_values.model_dump(exclude_unset=True)
+    for key in new_values_cleaned:
+        setattr(proof, key, new_values_cleaned[key])
+    db.commit()
+    db.refresh(proof)
+    return proof
 
 def delete_proof(db: Session, db_proof: ProofFull) -> bool:
     # we delete the image of the proof

--- a/app/routers/prices.py
+++ b/app/routers/prices.py
@@ -107,7 +107,7 @@ def create_price(
 )
 def update_price(
     price_id: int,
-    new_price: schemas.PriceBasicUpdatableFields,
+    price_new_values: schemas.PriceBasicUpdatableFields,
     current_user: schemas.UserCreate = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -133,7 +133,7 @@ def update_price(
         )
 
     # updated price
-    return crud.update_price(db, db_price, new_price)
+    return crud.update_price(db, db_price, price_new_values)
 
 
 @router.delete(

--- a/app/routers/proofs.py
+++ b/app/routers/proofs.py
@@ -90,6 +90,7 @@ def get_user_proof_by_id(
         )
     return db_proof
 
+
 @router.patch(
     path="/{proof_id}",
     response_model=schemas.ProofFull,
@@ -125,6 +126,7 @@ def update_proof(
 
     # updated proof
     return crud.update_proof(db, db_proof, new_proof)
+
 
 @router.delete(
     "/{proof_id}",

--- a/app/routers/proofs.py
+++ b/app/routers/proofs.py
@@ -98,7 +98,7 @@ def get_user_proof_by_id(
 )
 def update_proof(
     proof_id: int,
-    new_proof: schemas.ProofBasicUpdatableFields,
+    proof_new_values: schemas.ProofBasicUpdatableFields,
     current_user: schemas.UserCreate = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -125,7 +125,7 @@ def update_proof(
         )
 
     # updated proof
-    return crud.update_proof(db, db_proof, new_proof)
+    return crud.update_proof(db, db_proof, proof_new_values)
 
 
 @router.delete(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -157,6 +157,7 @@ class ProofFull(BaseModel):
     )
     created: datetime.datetime
 
+
 class ProofBasicUpdatableFields(BaseModel):
     type: ProofTypeEnum | None = None
     is_public: bool | None = None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -157,6 +157,13 @@ class ProofFull(BaseModel):
     )
     created: datetime.datetime
 
+class ProofBasicUpdatableFields(BaseModel):
+    type: ProofTypeEnum | None = None
+    is_public: bool | None = None
+
+    class Config:
+        extra = "forbid"
+
 
 # Price
 # ------------------------------------------------------------------------------

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -883,7 +883,7 @@ def test_update_proof(
         json=jsonable_encoder(PROOF_UPDATE_PARTIAL),
     )
     assert response.status_code == 200
-    assert response.json()["is_public"] == False
+    assert response.json()["is_public"] is False
     assert response.json()["type"] == proof.type.value
     # with authentication and proof owner more fields
     PROOF_UPDATE_PARTIAL_MORE = {**PROOF_UPDATE_PARTIAL, "type": "RECEIPT"}
@@ -893,7 +893,7 @@ def test_update_proof(
         json=jsonable_encoder(PROOF_UPDATE_PARTIAL_MORE),
     )
     assert response.status_code == 200
-    assert response.json()["is_public"] == False
+    assert response.json()["is_public"] is False
     assert response.json()["type"] != proof.type.value
     # with authentication and proof owner but extra fields
     PROOF_UPDATE_PARTIAL_WRONG = {**PROOF_UPDATE_PARTIAL, "owner": 1}


### PR DESCRIPTION
### What

- Added a PATCH /api/v1/proofs/{id} endpoint to allow update of boolean `is_public` and to change `type`

### Why

- `is_public` can only be set to `False` at creation/upload. Now user can correct this afterwards.
- Added `type` as patchable. In the frontend, a proof  `type` is automatically set depending on the "Add Price" mode selected. In the future, proof creation and price addition will be decoupled and a page dedicated to proof(s) upload in frontend should come soon. User might not set the right `type`.

Closes #236