### PR TITLE
fix(products): update products added first in Open Prices

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -137,7 +137,12 @@ def import_product_db(db: Session, batch_size: int = 1000) -> None:
             execute_result = db.execute(
                 update(Product)
                 .where(Product.code == product_code)
-                .where(Product.source == Flavor.off)
+                .where(
+                    or_(
+                        Product.source == Flavor.off,
+                        Product.source == None,  # noqa: E711, E501
+                    )
+                )
                 # Update the product if only if it has not been updated since
                 # the creation of the current dataset
                 .where(

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -151,7 +151,12 @@ def import_product_db(db: Session, batch_size: int = 1000) -> None:
                         Product.updated == None,  # noqa: E711, E501
                     )
                 )
-                .values(source=Flavor.off if item.get("source") is None else item.get("source"), **item)
+                .values(
+                    source=Flavor.off
+                    if item.get("source") is None
+                    else item.get("source"),
+                    **item,
+                )
             )
             updated_count += execute_result.rowcount
             buffer_len += 1

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -151,7 +151,7 @@ def import_product_db(db: Session, batch_size: int = 1000) -> None:
                         Product.updated == None,  # noqa: E711, E501
                     )
                 )
-                .values(**item)
+                .values(source=Flavor.off if item.get("source") is None else item.get("source"), **item)
             )
             updated_count += execute_result.rowcount
             buffer_len += 1


### PR DESCRIPTION
### What
Products first entered in Open Prices were not updated once added in OFF. Their "source" is set to None/null.

### Potential issue
- if user enters a product with barcode that is not a food product but has the same barcode as a food product (is that possible?)

### Fixes bug(s)
- #243 
