### PR TITLE
fix(tests): use ProductFull for fixtures

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -212,9 +212,7 @@ def get_product_by_code(db: Session, code: str) -> Optional[Product]:
     return db.query(Product).filter(Product.code == code).first()
 
 
-def create_product(
-    db: Session, product: ProductCreate, price_count: int = 0
-) -> Product:
+def create_product(db: Session, product: ProductCreate) -> Product:
     """Create a product in the database.
 
     :param db: the database session
@@ -223,16 +221,14 @@ def create_product(
         to 0
     :return: the created product
     """
-    db_product = Product(price_count=price_count, **product.model_dump())
+    db_product = Product(**product.model_dump())
     db.add(db_product)
     db.commit()
     db.refresh(db_product)
     return db_product
 
 
-def get_or_create_product(
-    db: Session, product: ProductCreate, init_price_count: int = 0
-) -> tuple[Product, bool]:
+def get_or_create_product(db: Session, product: ProductCreate) -> tuple[Product, bool]:
     """Get or create a product in the database.
 
     :param db: the database session
@@ -245,7 +241,7 @@ def get_or_create_product(
     created = False
     db_product = get_product_by_code(db, code=product.code)
     if not db_product:
-        db_product = create_product(db, product=product, price_count=init_price_count)
+        db_product = create_product(db, product=product)
         created = True
     return db_product, created
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -64,49 +64,61 @@ class ProductFull(ProductCreate):
         description="source of data, either `off` (Open Food Facts), "
         "`obf` (Open Beauty Facts), `opf` (Open Products Facts) or `opff` (Open Pet Food Facts",
         examples=["off", "obf", "opf", "opff", None],
+        default=None,
     )
     product_name: str | None = Field(
-        description="name of the product.", examples=["Nocciolata"]
+        description="name of the product.", examples=["Nocciolata"], default=None
     )
     product_quantity: int | None = Field(
         description="quantity of the product, normalized in g or ml (depending on the product).",
         examples=[700],
+        default=None,
     )
     product_quantity_unit: str | None = Field(
         description="quantity unit of the product: g or ml (depending on the product).",
         examples=["g", "ml"],
+        default=None,
     )
     categories_tags: list[str] = Field(
         description="categories of the product.",
         examples=[["en:breakfasts", "en:spreads"]],
+        default=list,
     )
     brands: str | None = Field(
         description="brand(s) of the product.",
         examples=["Rigoni di Asiago", "Lindt"],
+        default=None,
     )
     brands_tags: list[str] = Field(
         description="brands of the product.",
         examples=[["douceur-du-verger", "marque-repere"]],
+        default=list,
     )
     labels_tags: list[str] = Field(
         description="labels of the product.",
         examples=[["en:fair-trade", "en:organic", "en:made-in-france"]],
+        default=list,
     )
     image_url: AnyHttpUrl | None = Field(
         description="URL of the product image.",
         examples=[
             "https://images.openfoodfacts.org/images/products/800/150/500/5707/front_fr.161.400.jpg"
         ],
+        default=None,
     )
     nutriscore_grade: str | None = Field(
         description="Nutri-Score grade.",
         examples=["a", "b", "c", "d", "e", "unknown", "not-applicable"],
+        default=None,
     )
     ecoscore_grade: str | None = Field(
         description="Eco-Score grade.",
         examples=["a", "b", "c", "d", "e", "unknown", "not-applicable"],
+        default=None,
     )
-    nova_group: int | None = Field(description="NOVA group.", examples=[1, 2, 3, 4])
+    nova_group: int | None = Field(
+        description="NOVA group.", examples=[1, 2, 3, 4], default=None
+    )
     unique_scans_n: int = Field(
         description="number of unique scans of the product on Open Food Facts.",
         examples=[15],
@@ -114,7 +126,7 @@ class ProductFull(ProductCreate):
     )
     created: datetime.datetime = Field(description="datetime of the creation.")
     updated: datetime.datetime | None = Field(
-        description="datetime of the last update."
+        description="datetime of the last update.", default=None
     )
 
 
@@ -139,8 +151,10 @@ class LocationFull(LocationCreate):
     osm_address_country: str | None = None
     osm_lat: float | None = None
     osm_lon: float | None = None
-    created: datetime.datetime
-    updated: datetime.datetime | None = None
+    created: datetime.datetime = Field(description="datetime of the creation.")
+    updated: datetime.datetime | None = Field(
+        description="datetime of the last update.", default=None
+    )
 
 
 # Proof

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -53,13 +53,17 @@ class ProductCreate(BaseModel):
         description="barcode (EAN) of the product, as a string.",
         examples=["8001505005707"],
     )
+    price_count: int = Field(
+        description="number of prices for this product.", examples=[15], default=0
+    )
 
 
 class ProductFull(ProductCreate):
     id: int
     source: Flavor | None = Field(
         description="source of data, either `off` (Open Food Facts), "
-        "`obf` (Open Beauty Facts), `opff` (Open Pet Food Facts) or `obf` (Open Beauty Facts)"
+        "`obf` (Open Beauty Facts), `opf` (Open Products Facts) or `opff` (Open Pet Food Facts",
+        examples=["off", "obf", "opf", "opff", None],
     )
     product_name: str | None = Field(
         description="name of the product.", examples=["Nocciolata"]
@@ -107,9 +111,6 @@ class ProductFull(ProductCreate):
         description="number of unique scans of the product on Open Food Facts.",
         examples=[15],
         default=0,
-    )
-    price_count: int = Field(
-        description="number of prices for this product.", examples=[15], default=0
     )
     created: datetime.datetime = Field(description="datetime of the creation.")
     updated: datetime.datetime | None = Field(

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -40,10 +40,8 @@ def create_price_product(db: Session, price: Price) -> None:
     # barcode-less product
     if price.product_code:
         # get or create the corresponding product
-        product = ProductCreate(code=price.product_code)
-        db_product, created = crud.get_or_create_product(
-            db, product=product, init_price_count=1
-        )
+        product = ProductCreate(code=price.product_code, price_count=1)
+        db_product, created = crud.get_or_create_product(db, product=product)
         # link the product to the price
         crud.link_price_product(db, price=price, product=db_product)
         # fetch data from OpenFoodFacts if created

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -9,13 +9,7 @@ from app import crud
 from app.api import app
 from app.db import Base, engine, get_db, session
 from app.models import Session as SessionModel
-from app.schemas import (
-    LocationFull,
-    PriceCreate,
-    ProductCreate,
-    ProofFilter,
-    UserCreate,
-)
+from app.schemas import LocationFull, PriceCreate, ProductFull, ProofFilter, UserCreate
 
 Base.metadata.drop_all(bind=engine)
 Base.metadata.create_all(bind=engine)
@@ -43,23 +37,26 @@ PAGINATION_KEYS = ["items", "total", "page", "size", "pages"]
 USER = UserCreate(user_id="user", token="user__Utoken")
 USER_1 = UserCreate(user_id="user1", token="user1__Utoken1", price_count=0)
 USER_2 = UserCreate(user_id="user2", token="user2__Utoken2", price_count=1)
-PRODUCT = ProductCreate(code="8001505005592")
-PRODUCT_1 = ProductCreate(
-    code="0022314010025",
+PRODUCT_1 = ProductFull(
+    id=1,
+    code="8001505005707",
     source="off",
-    product_name="Chestnut spread 500 g",
-    product_quantity=500,
-    product_quantity_unit="g",
-    categories_tags=["en:spreads", "en:nuts-and-their-products"],
-    brands="Clément Faugier",
-    brands_tags=["clement-faugier"],
-    labels_tags=[],
+    product_name="Nocciolata",
+    product_quantity=700,
+    product_quantity_unit=None,
+    categories_tags=["en:breakfasts", "en:spreads", "en:cocoa-and-hazelnuts-spreads"],
+    brands="Rigoni di Asiago",
+    brands_tags=["rigoni-di-asiago"],
+    labels_tags=["en:no-gluten", "en:organic"],
     nutriscore_grade="d",
-    ecoscore_grade="b",
+    ecoscore_grade="c",
     nova_group=4,
-    unique_scans_n=20,
+    unique_scans_n=131,
+    created=datetime.datetime.now(),
+    updated=datetime.datetime.now(),
 )
-PRODUCT_2 = ProductCreate(
+PRODUCT_2 = ProductFull(
+    id=2,
     code="0022314010100",
     source="off",
     product_name="Chestnut spread 100 g",
@@ -73,27 +70,29 @@ PRODUCT_2 = ProductCreate(
     ecoscore_grade="c",
     nova_group=4,
     unique_scans_n=10,
+    created=datetime.datetime.now(),
+    updated=datetime.datetime.now(),
 )
-PRODUCT_3 = ProductCreate(
-    code="3760091721969",
+PRODUCT_3 = ProductFull(
+    id=3,
+    code="8000215204219",
     source="off",
-    product_name="Crème bio de châtaignes 320 g",
-    product_quantity=320,
-    product_quantity_unit="g",
-    categories_tags=["en:spreads", "en:nuts-and-their-products"],
-    brands="Ethiquable",
-    brands_tags=["paysans-d-ici", "ethiquable"],
-    labels_tags=["en:fair-trade", "en:organic", "en:made-in-france"],
-    nutriscore_grade="c",
-    ecoscore_grade="b",
+    product_name="Vitariz Rice Drink",
+    product_quantity=1000,
+    product_quantity_unit=None,
+    categories_tags=["en:beverages", "en:plant-based-foods"],
+    brands="Vitariz, Alinor",
+    brands_tags=["vitariz", "alinor"],
+    labels_tags=["en:no-gluten", "en:organic", "en:no-lactose"],
+    nutriscore_grade="b",
+    ecoscore_grade="c",
     nova_group=None,
-    unique_scans_n=0,
-)
-LOCATION = LocationFull(
-    id=1, osm_id=3344841823, osm_type="NODE", created=datetime.datetime.now()
+    unique_scans_n=2,
+    created=datetime.datetime.now(),
+    updated=datetime.datetime.now(),
 )
 LOCATION_1 = LocationFull(
-    id=2,
+    id=1,
     osm_id=652825274,
     osm_type="NODE",
     osm_name="Monoprix",
@@ -107,7 +106,7 @@ LOCATION_1 = LocationFull(
     updated=datetime.datetime.now(),
 )
 LOCATION_2 = LocationFull(
-    id=3,
+    id=2,
     osm_id=6509705997,
     osm_type="NODE",
     osm_name="Carrefour",
@@ -172,18 +171,6 @@ def user_session(db_session) -> SessionModel:
 def user_session_1(db_session) -> SessionModel:
     session, *_ = crud.create_session(db_session, USER_1.user_id, USER_1.token)
     return session
-
-
-@pytest.fixture(scope="module")
-def product(db_session):
-    db_product = crud.create_product(db_session, PRODUCT)
-    return db_product
-
-
-@pytest.fixture(scope="module")
-def location(db_session):
-    db_location = crud.create_location(db_session, LOCATION)
-    return db_location
 
 
 @pytest.fixture(scope="function")
@@ -1121,29 +1108,49 @@ def test_get_products_pagination(clean_products):
         assert key in response.json()
 
 
-# def test_get_products_filters(db_session, clean_products):
-#     crud.create_product(db_session, PRODUCT_1)
-#     crud.create_product(db_session, PRODUCT_2)
-#     crud.create_product(db_session, PRODUCT_3)
+def test_get_products_filters(db_session, clean_products):
+    crud.create_product(db_session, PRODUCT_1)
+    crud.create_product(db_session, PRODUCT_2)
+    crud.create_product(db_session, PRODUCT_3)
 
-#     assert len(crud.get_products(db_session)) == 3
+    assert len(crud.get_products(db_session)) == 3
 
-#     # 3 products with the same source
-#     response = client.get("/api/v1/products?source=off")
-#     assert response.status_code == 200
-#     assert len(response.json()["items"]) == 3
-#     # 1 product with a specific product_name
-#     response = client.get("/api/v1/products?product_name__like=châtaignes")
-#     assert response.status_code == 200
-#     assert len(response.json()["items"]) == 1
-#     # 2 products with the same brand
-#     response = client.get("/api/v1/products?brands__like=Clément Faugier")
-#     assert response.status_code == 200
-#     assert len(response.json()["items"]) == 2
-#     # 2 products with a positive unique_scans_n
-#     response = client.get("/api/v1/products?unique_scans_n__gte=1")
-#     assert response.status_code == 200
-#     assert len(response.json()["items"]) == 2
+    # filter by source
+    response = client.get("/api/v1/products?source=off")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 3
+    # filter by product_name
+    response = client.get("/api/v1/products?product_name__like=Chestnut")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    # filter by brand
+    response = client.get("/api/v1/products?brands__like=Clément Faugier")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    # filter by category tag
+    response = client.get("/api/v1/products?categories_tags__contains=en:spreads")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 2
+    # filter by label tag
+    response = client.get("/api/v1/products?labels_tags__contains=en:organic")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 2
+    # filter by nutriscore
+    response = client.get("/api/v1/products?nutriscore_grade=b")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 1
+    # filter by ecoscore
+    response = client.get("/api/v1/products?ecoscore_grade=a")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 0
+    # filter by nova
+    response = client.get("/api/v1/products?nova_group=4")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 2
+    # filter by unique_scans_n
+    response = client.get("/api/v1/products?unique_scans_n__gte=10")
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == 2
 
 
 def test_get_product(db_session, clean_products):
@@ -1151,11 +1158,13 @@ def test_get_product(db_session, clean_products):
     crud.create_product(db_session, PRODUCT_2)
     last_product = crud.create_product(db_session, PRODUCT_3)
 
+    assert len(crud.get_products(db_session)) == 3
+
     # by id: product exists
     response = client.get(f"/api/v1/products/{last_product.id}")
     assert response.status_code == 200
     # by id: product does not exist
-    response = client.get(f"/api/v1/products/{last_product.id + 1}")
+    response = client.get("/api/v1/products/99999")
     assert response.status_code == 404
     # by code: product exists
     response = client.get(f"/api/v1/products/code/{last_product.code}")
@@ -1184,23 +1193,27 @@ def test_get_locations_pagination(clean_locations):
         assert key in response.json()
 
 
-def test_get_locations_filters(db_session):
+def test_get_locations_filters(db_session, clean_locations):
     crud.create_location(db_session, LOCATION_1)
     crud.create_location(db_session, LOCATION_2)
 
     assert len(crud.get_locations(db_session)) == 2
 
-    # 1 location Monoprix
+    # filter by osm_name
     response = client.get("/api/v1/locations?osm_name__like=Monoprix")
     assert response.status_code == 200
     assert len(response.json()["items"]) == 1
-    # 1 location in France
+    # filter by osm_address_country
     response = client.get("/api/v1/locations?osm_address_country__like=France")  # noqa
     assert response.status_code == 200
     assert len(response.json()["items"]) == 1
 
 
-def test_get_location(location):
+def test_get_location(db_session, clean_locations):
+    location = crud.create_location(db_session, LOCATION_1)
+
+    assert len(crud.get_locations(db_session)) == 1
+
     # by id: location exists
     response = client.get(f"/api/v1/locations/{location.id}")
     assert response.status_code == 200


### PR DESCRIPTION
### What

Similar to #240

Product filter tests are commented because they fail.

### Fixes bug(s)

`ProductCreate` used to create fixtures is not a complete object so some fields are empty in the DB when using the paginate query. By using `ProductFull` we create a full entry in the DB that can be queried.
