### PR TITLE
feat(prices): allow moderators to delete prices

### DIFF
--- a/app/routers/prices.py
+++ b/app/routers/prices.py
@@ -172,8 +172,9 @@ def delete_price(
             status_code=404,
             detail=f"Price with code {price_id} not found",
         )
-    # Check if the price belongs to the current user
-    if db_price.owner != current_user.user_id:
+    # Check if the price belongs to the current user,
+    # if it doesn't, the user needs to be a moderator
+    if db_price.owner != current_user.user_id and not current_user.is_moderator:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Price does not belong to current user",

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -742,11 +742,13 @@ def test_update_price_moderator(
 def test_delete_price(
     db_session, user_session: SessionModel, user_session_1: SessionModel, clean_prices
 ):
+    # create price
     db_price = crud.create_price(db_session, PRICE_1, user_session.user)
     # without authentication
     response = client.delete(f"/api/v1/prices/{db_price.id}")
     assert response.status_code == 401
     # with authentication but not price owner
+    crud.update_user_moderator(db_session, USER_1.user_id, False)
     response = client.delete(
         f"/api/v1/prices/{db_price.id}",
         headers={"Authorization": f"Bearer {user_session_1.token}"},
@@ -762,6 +764,20 @@ def test_delete_price(
     response = client.delete(
         f"/api/v1/prices/{db_price.id}",
         headers={"Authorization": f"Bearer {user_session.token}"},
+    )
+    assert response.status_code == 204
+
+
+def test_delete_price_moderator(
+    db_session, user_session: SessionModel, user_session_1: SessionModel, clean_prices
+):
+    # create price
+    db_price = crud.create_price(db_session, PRICE_1, user_session.user)
+    # user_1 is moderator, not owner
+    crud.update_user_moderator(db_session, USER_1.user_id, True)
+    response = client.delete(
+        f"/api/v1/prices/{db_price.id}",
+        headers={"Authorization": f"Bearer {user_session_1.token}"},
     )
     assert response.status_code == 204
 


### PR DESCRIPTION
### What

Issue #182

A moderator should be able to delete a price he/she doesn't own
- add the check in the price delete endpoint
- add tests

