### PR TITLE
fix(data): fix daily data import script

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -171,10 +171,15 @@ def import_product_db(
             updated_count += execute_result.rowcount
             buffer_len += 1
 
+        # update the database regularly
         if buffer_len % batch_size == 0:
             db.commit()
             logger.info(f"Products: {added_count} added, {updated_count} updated")
             buffer_len = 0
+
+    # final database update
+    db.commit()
+    logger.info(f"Products: {added_count} added, {updated_count} updated. Done!")
 
 
 # Locations


### PR DESCRIPTION
### What

In #119 we added the `import_product_db` function that added or updated products from the OFF database (and in #264 we also sync products from OBF, OPF & OPFF). 

But some recently added products in OBF or OPF did not seem to appear the next day in OP.

The issue seemed to be the frequency of `db.commit()` in the script, done in batch but it would forget the very last product changes.