### PR TITLE
refactor(prices): reorganise schema inheritance to validate price updates

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -18,9 +18,9 @@ from app.models import User
 from app.schemas import (
     LocationCreate,
     LocationFilter,
-    PriceBasicUpdatableFields,
     PriceCreate,
     PriceFilter,
+    PriceUpdate,
     ProductCreate,
     ProductFilter,
     ProductFull,
@@ -345,9 +345,7 @@ def delete_price(db: Session, db_price: Price) -> bool:
     return True
 
 
-def update_price(
-    db: Session, price: Price, new_values: PriceBasicUpdatableFields
-) -> Price:
+def update_price(db: Session, price: Price, new_values: PriceUpdate) -> Price:
     new_values_cleaned = new_values.model_dump(exclude_unset=True)
     for key in new_values_cleaned:
         setattr(price, key, new_values_cleaned[key])

--- a/app/routers/prices.py
+++ b/app/routers/prices.py
@@ -29,7 +29,7 @@ def get_prices(
     status_code=status.HTTP_201_CREATED,
 )
 def create_price(
-    price: schemas.PriceCreateWithValidation,
+    price: schemas.PriceCreate,
     background_tasks: BackgroundTasks,
     current_user: schemas.UserCreate = Depends(get_current_user),
     app_name: str | None = None,
@@ -77,7 +77,7 @@ def create_price(
 )
 def update_price(
     price_id: int,
-    price_new_values: schemas.PriceBasicUpdatableFields,
+    price_new_values: schemas.PriceUpdate,
     current_user: schemas.UserCreate = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> Price:

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -3,12 +3,12 @@ import datetime
 import pydantic
 import pytest
 
-from app.schemas import CurrencyEnum, LocationOSMEnum, PriceCreateWithValidation
+from app.schemas import CurrencyEnum, LocationOSMEnum, PriceCreate
 
 
 class TestPriceCreate:
     def test_simple_price_with_barcode(self):
-        price = PriceCreateWithValidation(
+        price = PriceCreate(
             product_code="5414661000456",
             location_osm_id=123,
             location_osm_type=LocationOSMEnum.NODE,
@@ -24,7 +24,7 @@ class TestPriceCreate:
         assert price.date == datetime.date.fromisoformat("2021-01-01")
 
     def test_simple_price_with_category(self):
-        price = PriceCreateWithValidation(
+        price = PriceCreate(
             category_tag="en:Fresh-apricots",
             labels_tags=["en:Organic", "fr:AB-agriculture-biologique"],
             origins_tags=["en:California", "en:Sweden"],
@@ -40,7 +40,7 @@ class TestPriceCreate:
 
     def test_simple_price_with_invalid_taxonomized_values(self):
         with pytest.raises(pydantic.ValidationError, match="Invalid category tag"):
-            PriceCreateWithValidation(
+            PriceCreate(
                 category_tag="en:unknown-category",
                 location_osm_id=123,
                 location_osm_type=LocationOSMEnum.NODE,
@@ -50,7 +50,7 @@ class TestPriceCreate:
             )
 
         with pytest.raises(pydantic.ValidationError, match="Invalid label tag"):
-            PriceCreateWithValidation(
+            PriceCreate(
                 category_tag="en:carrots",
                 labels_tags=["en:invalid"],
                 location_osm_id=123,
@@ -61,7 +61,7 @@ class TestPriceCreate:
             )
 
         with pytest.raises(pydantic.ValidationError, match="Invalid origin tag"):
-            PriceCreateWithValidation(
+            PriceCreate(
                 category_tag="en:carrots",
                 origins_tags=["en:invalid"],
                 location_osm_id=123,
@@ -76,7 +76,7 @@ class TestPriceCreate:
             pydantic.ValidationError,
             match="`labels_tags` can only be set for products without barcode",
         ):
-            PriceCreateWithValidation(
+            PriceCreate(
                 product_code="5414661000456",
                 labels_tags=["en:Organic", "fr:AB-agriculture-biologique"],
                 location_osm_id=123,
@@ -91,7 +91,7 @@ class TestPriceCreate:
             pydantic.ValidationError,
             match="`price_is_discounted` must be true if `price_without_discount` is filled",
         ):
-            PriceCreateWithValidation(
+            PriceCreate(
                 product_code="5414661000456",
                 location_osm_id=123,
                 location_osm_type=LocationOSMEnum.NODE,
@@ -105,7 +105,7 @@ class TestPriceCreate:
             pydantic.ValidationError,
             match="`price_without_discount` must be greater than `price`",
         ):
-            PriceCreateWithValidation(
+            PriceCreate(
                 product_code="5414661000456",
                 location_osm_id=123,
                 location_osm_type=LocationOSMEnum.NODE,


### PR DESCRIPTION
### What

Currently we don't have any validation on `PriceBasicUpdatableFields`, so a user could add a negative price...
Related to this comment : https://github.com/openfoodfacts/openfoodfacts-dart/issues/942#issuecomment-2193797666

### How

- new `PriceBase` schema
- renamed `PriceBasicUpdatableFields` to `PriceUpdate`
- made all fields of `PriceUpdate` optional (for the PATCH method)
- added their WithValidation counterparts, to validation on creation/update, but skip on get (to speed up !)

### Todo

It still doesn't validate the edition of the `price_per` field, because it relies on fields (`product_code`, `category_tags`) that are not available in the `PriceBase` schema... :thinking: 

### Useful links

- https://stackoverflow.com/a/76560886/4293684
- https://fastapi.tiangolo.com/tutorial/body-updates/
- https://fastapi.tiangolo.com/tutorial/extra-models/