### PR TITLE
ci: revert release-please config to v3

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,16 +3,26 @@ name: Run release-please
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: GoogleCloudPlatform/release-please-action@v3.7.13
         with:
           # We can't use GITHUB_TOKEN here because, github actions can't provocate actions
           # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
           # So this is a personnal access token
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: simple
+          changelog-types: |
+            [
+              {"type":"feat","section":"Features","hidden":false},
+              {"type":"fix","section":"Bug Fixes","hidden":false},
+              {"type":"style","section":"Technical","hidden":false},
+              {"type":"docs","section":"Technical","hidden":false},
+              {"type":"test","section":"Technical","hidden":false},
+              {"type":"chore","section":"Technical","hidden":false},
+              {"type":"refactor","section":"Technical","hidden":false}
+            ]


### PR DESCRIPTION
### What

Following #333 the issue with PRs not appearing in the release-please PRs seem to be related with the config, and the version.

I reverted to the same config as the frontend repo : https://github.com/openfoodfacts/open-prices-frontend/blob/master/.github/workflows/release-please.yml