### PR TITLE
feat(Django): daily sync of products from OFF

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -32,6 +32,7 @@ THIRD_PARTY_APPS = [
     "rest_framework",  # djangorestframework
     "django_filters",  # django-filter
     "drf_spectacular",  # drf-spectacular
+    "django_q",  # django-q2
     # "debug_toolbar",  # django-debug-toolbar (see below)
     "django_extensions",  # django-extensions
 ]
@@ -167,6 +168,20 @@ SPECTACULAR_SETTINGS = {
     },
 }
 
+# Django Q2
+# https://django-q2.readthedocs.io/
+# ------------------------------------------------------------------------------
+
+Q_CLUSTER = {
+    "name": "DjangORM",
+    "workers": 1,
+    "timeout": 90,
+    "retry": 120,
+    "queue_limit": 50,
+    "bulk": 10,
+    "orm": "default",
+}
+
 
 # Django Debug Toolbar
 # https://django-debug-toolbar.readthedocs.io/
@@ -175,6 +190,16 @@ SPECTACULAR_SETTINGS = {
 if DEBUG:
     INSTALLED_APPS += ["debug_toolbar"]
     MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
+
+
+# Shell Plus (django-extensions)
+# ------------------------------------------------------------------------------
+
+SHELL_PLUS_POST_IMPORTS = [
+    "import openfoodfacts",
+    "from open_prices.common import openfoodfacts as common_openfoodfacts",
+    "from open_prices.common import openstreetmap as common_openstreetmap",
+]
 
 
 # Authentication

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -1,6 +1,19 @@
+import datetime
+
 import requests
+import tqdm
 from django.conf import settings
-from openfoodfacts import API, APIVersion, Country, Environment, Flavor
+from django.db.models import Q
+from django.utils import timezone
+from openfoodfacts import (
+    API,
+    APIVersion,
+    Country,
+    DatasetType,
+    Environment,
+    Flavor,
+    ProductDataset,
+)
 from openfoodfacts.images import generate_image_url
 from openfoodfacts.types import JSONType
 
@@ -8,10 +21,10 @@ OFF_FIELDS = [
     "product_name",
     "product_quantity",
     "product_quantity_unit",
-    "categories_tags",
+    # "categories_tags",
     "brands",
-    "brands_tags",
-    "labels_tags",
+    # "brands_tags",
+    # "labels_tags",
     "image_url",
     "nutriscore_grade",
     "ecoscore_grade",
@@ -107,3 +120,133 @@ def get_product_dict(product, flavor=Flavor.off) -> JSONType | None:
     except Exception:
         # logger.exception("Error returned from Open Food Facts")
         return None
+
+
+def import_product_db(flavor: Flavor = Flavor.off, batch_size: int = 1000) -> None:
+    """Import from DB JSONL dump to create/update product table.
+
+    :param db: the session to use
+    :param batch_size: the number of products to create/update in a single
+      transaction, defaults to 1000
+    """
+    from open_prices.products.models import Product
+
+    print((f"Launching import_product_db ({flavor})"))
+    existing_product_flavor_codes = set(
+        Product.objects.filter(source=flavor).values_list("code", flat=True)
+    )
+    print(
+        f"Number of existing Product codes (from {flavor}): {len(existing_product_flavor_codes)}"
+    )
+    dataset = ProductDataset(
+        flavor=flavor,
+        dataset_type=DatasetType.jsonl,
+        force_download=True,
+        download_newer=True,
+    )
+
+    seen_codes = set()
+    products_to_create_or_update = list()
+    added_count = 0
+    updated_count = 0
+    # the dataset was created after the start of the day, every product updated
+    # after should be skipped, as we don't know the exact creation time of the
+    # dump
+    start_datetime = datetime.datetime.now(tz=datetime.timezone.utc).replace(
+        hour=0, minute=0, second=0
+    )
+
+    for product in tqdm.tqdm(dataset):
+        # Skip products without a code, or with wrong code
+        if ("code" not in product) or (not product["code"].isdigit()):
+            continue
+        product_code = product["code"]
+
+        # Skip duplicate products
+        if product_code in seen_codes:
+            continue
+        seen_codes.add(product_code)
+
+        # Some products have no "lang" field (especially non-OFF products)
+        product_lang = product.get("lang", product.get("lc", "en"))
+        # Store images & last_modified_t
+        product_images: JSONType = product.get("images", {})
+        product_last_modified_t = product.get("last_modified_t")
+
+        # Convert last_modified_t to a datetime object
+        # (sometimes the field is a string, convert to int first)
+        if isinstance(product_last_modified_t, str):
+            product_last_modified_t = int(product_last_modified_t)
+        product_source_last_modified = (
+            datetime.datetime.fromtimestamp(
+                product_last_modified_t, tz=datetime.timezone.utc
+            )
+            if product_last_modified_t
+            else None
+        )
+        # Skip products that have no last_modified date
+        if product_source_last_modified is None:
+            continue
+
+        # Skip products that have been modified today (more recent updates are
+        # possible)
+        if product_source_last_modified >= start_datetime:
+            print(f"Skipping {product_code}")
+            continue
+
+        # Build product dict to create/update
+        product_dict = {
+            key: product[key] if (key in product) else None for key in OFF_FIELDS
+        }
+        product_dict["image_url"] = generate_main_image_url(
+            product_code, product_images, product_lang, flavor=flavor
+        )
+        product_dict["source"] = flavor
+        product_dict["source_last_synced"] = timezone.now()
+        product_dict = normalize_product_fields(product_dict)
+
+        # Case 1: new OFF product (not in OP database)
+        if product_code not in existing_product_flavor_codes:
+            product_dict["code"] = product_code
+            products_to_create_or_update.append(Product(**product_dict))
+            added_count += 1
+
+        # Case 2: existing product (already in OP database)
+        else:
+            # Update the product if it:
+            # - is part of the current flavor sync (or if it has no source (created in Open Prices before OFF))  # noqa
+            # - has not been updated since the creation of the current dataset
+            existing_product_qs = (
+                Product.objects.filter(code=product_code)
+                .filter(Q(source=flavor) | Q(source=None))
+                .filter(
+                    Q(source_last_synced__lt=product_source_last_modified)
+                    | Q(source_last_synced=None)
+                )
+            )
+            if existing_product_qs.exists():
+                products_to_create_or_update.append(Product(**product_dict))
+                updated_count += 1
+
+        # update the database regularly
+        if (
+            len(products_to_create_or_update)
+            and len(products_to_create_or_update) % batch_size == 0
+        ):
+            Product.objects.bulk_create(
+                products_to_create_or_update,
+                update_conflicts=True,
+                update_fields=OFF_FIELDS,
+                unique_fields=["code"],
+            )
+            print(f"Products: {added_count} added, {updated_count} updated")
+            products_to_create_or_update = list()
+
+    # final database update
+    Product.objects.bulk_create(
+        products_to_create_or_update,
+        update_conflicts=True,
+        update_fields=OFF_FIELDS,
+        unique_fields=["code"],
+    )
+    print(f"Products: {added_count} added, {updated_count} updated. Done!")

--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -1,0 +1,20 @@
+from django_q.models import Schedule
+from django_q.tasks import schedule
+from openfoodfacts import Flavor
+
+from open_prices.common.openfoodfacts import import_product_db
+
+
+def import_product_db_task():
+    for flavor in [Flavor.off, Flavor.obf, Flavor.opff, Flavor.opf]:
+        import_product_db(flavor=flavor)
+
+
+# sync product database with Open Food Facts daily at 15:00
+# https://cron.help/#0_15_*_*_*
+schedule(
+    "open_prices.common.tasks.import_product_db_task",
+    name="import_product_db_task",
+    schedule_type=Schedule.CRON,
+    cron="0 15 * * *",
+)

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,6 +31,17 @@ files = [
 ]
 
 [[package]]
+name = "ansicon"
+version = "1.89.0"
+description = "Python wrapper for loading Jason Hood's ANSICON"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec"},
+    {file = "ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1"},
+]
+
+[[package]]
 name = "anyio"
 version = "3.7.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -189,6 +200,22 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "blessed"
+version = "1.20.0"
+description = "Easy, practical library for making terminal apps, by providing an elegant, well-documented interface to Colors, Keyboard input, and screen Positioning capabilities."
+optional = false
+python-versions = ">=2.7"
+files = [
+    {file = "blessed-1.20.0-py2.py3-none-any.whl", hash = "sha256:0c542922586a265e699188e52d5f5ac5ec0dd517e5a1041d90d2bbf23f906058"},
+    {file = "blessed-1.20.0.tar.gz", hash = "sha256:2cdd67f8746e048f00df47a2880f4d6acbcdb399031b604e34ba8f71d5787680"},
+]
+
+[package.dependencies]
+jinxed = {version = ">=1.1.0", markers = "platform_system == \"Windows\""}
+six = ">=1.9.0"
+wcwidth = ">=0.1.4"
 
 [[package]]
 name = "bracex"
@@ -475,6 +502,21 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "croniter"
+version = "3.0.3"
+description = "croniter provides iteration for datetime object with cron like format"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.6"
+files = [
+    {file = "croniter-3.0.3-py2.py3-none-any.whl", hash = "sha256:b3bd11f270dc54ccd1f2397b813436015a86d30ffc5a7a9438eec1ed916f2101"},
+    {file = "croniter-3.0.3.tar.gz", hash = "sha256:34117ec1741f10a7bd0ec3ad7d8f0eb8fa457a2feb9be32e6a2250e158957668"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = ">2021.1"
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
@@ -562,6 +604,43 @@ files = [
 
 [package.dependencies]
 Django = ">=4.2"
+
+[[package]]
+name = "django-picklefield"
+version = "3.2"
+description = "Pickled object field for Django"
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "django-picklefield-3.2.tar.gz", hash = "sha256:aa463f5d79d497dbe789f14b45180f00a51d0d670067d0729f352a3941cdfa4d"},
+    {file = "django_picklefield-3.2-py3-none-any.whl", hash = "sha256:e9a73539d110f69825d9320db18bcb82e5189ff48dbed41821c026a20497764c"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+
+[package.extras]
+tests = ["tox"]
+
+[[package]]
+name = "django-q2"
+version = "1.6.2"
+description = "A multiprocessing distributed task queue for Django"
+optional = false
+python-versions = ">=3.8,<4"
+files = [
+    {file = "django_q2-1.6.2-py3-none-any.whl", hash = "sha256:c2d75552c80b83ca0d8c0b0db7db4f17e9f43ee131a46d0ddd514c5f5fc603cb"},
+    {file = "django_q2-1.6.2.tar.gz", hash = "sha256:cd83c16b5791cd99f83a8d106d2447305d73c6c8ed8ec22c7cb954fe0e814284"},
+]
+
+[package.dependencies]
+django = ">=3.2,<6"
+django-picklefield = ">=3.1,<4.0"
+
+[package.extras]
+rollbar = ["django-q-rollbar (>=0.1)"]
+sentry = ["django-q-sentry (>=0.1)"]
+testing = ["blessed (>=1.19.1,<2.0.0)", "boto3 (>=1.24.92,<2.0.0)", "croniter (>=2.0.1,<3.0.0)", "django-redis (>=5.2.0,<6.0.0)", "hiredis (>=2.0.0,<3.0.0)", "iron-mq (>=0.9,<0.10)", "psutil (>=5.9.2,<6.0.0)", "pymongo (>=4.2.0,<5.0.0)", "redis (>=4.3.4,<5.0.0)", "setproctitle (>=1.3.2,<2.0.0)"]
 
 [[package]]
 name = "djangorestframework"
@@ -1034,6 +1113,20 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jinxed"
+version = "1.3.0"
+description = "Jinxed Terminal Library"
+optional = false
+python-versions = "*"
+files = [
+    {file = "jinxed-1.3.0-py2.py3-none-any.whl", hash = "sha256:b993189f39dc2d7504d802152671535b06d380b26d78070559551cbf92df4fc5"},
+    {file = "jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf"},
+]
+
+[package.dependencies]
+ansicon = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "jsonschema"
@@ -3210,6 +3303,17 @@ files = [
 bracex = ">=2.1.1"
 
 [[package]]
+name = "wcwidth"
+version = "0.2.13"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
+    {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
+]
+
+[[package]]
 name = "xarray"
 version = "2024.2.0"
 description = "N-D labeled arrays and datasets in Python"
@@ -3236,4 +3340,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "151aaa170f1469fdf3a579d77b96a318e0590542a3b4d5261f4e40e016b81a72"
+content-hash = "72293ef70681f2fee856c1eba85357b4cc079f7a85960a4f298a961922d36c3c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ djangorestframework = "^3.15.2"
 drf-spectacular = "^0.27.2"
 django-filter = "^24.2"
 factory-boy = "^3.3.0"
+django-q2 = "^1.6.2"
+croniter = "^3.0.3"
+blessed = "^1.20.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "~23.12.1"


### PR DESCRIPTION
### What

Installed `django-q2`
```
poetry add django-q2 blessed croniter
```
- with 2 extra packages
- using the DB as message broker
- why this package ? See #355 for a comparison

### Commands

Create scheduled task (how to create automatically ?)
```
from django_q.models import Schedule

Schedule.objects.create(func="open_prices.common.openfoodfacts.import_product_db_full", schedule_type=Schedule.CRON, cron="0 15 * * *")
```

Sync product flavor manually
```
// python manage.py shell_plus
import openfoodfacts
from open_prices.common import openfoodfacts as common_openfoodfacts

common_openfoodfacts.import_product_db(flavor=openfoodfacts.Flavor.opf)
```