### PR TITLE
refactor(Django): improve API serializers

### DIFF
--- a/open_prices/api/locations/serializers.py
+++ b/open_prices/api/locations/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from open_prices.locations.models import Location
 
 
-class LocationFullSerializer(serializers.ModelSerializer):
+class LocationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Location
         fields = "__all__"

--- a/open_prices/api/locations/views.py
+++ b/open_prices/api/locations/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from open_prices.api.locations.filters import LocationFilter
 from open_prices.api.locations.serializers import (
     LocationCreateSerializer,
-    LocationFullSerializer,
+    LocationSerializer,
 )
 from open_prices.locations.models import Location
 
@@ -20,7 +20,7 @@ class LocationViewSet(
     viewsets.GenericViewSet,
 ):
     queryset = Location.objects.all()
-    serializer_class = LocationFullSerializer
+    serializer_class = LocationSerializer
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filterset_class = LocationFilter
     ordering_fields = ["price_count"]

--- a/open_prices/api/prices/serializers.py
+++ b/open_prices/api/prices/serializers.py
@@ -1,21 +1,39 @@
 from rest_framework import serializers
 
-from open_prices.api.locations.serializers import LocationFullSerializer
+from open_prices.api.locations.serializers import LocationSerializer
 from open_prices.api.products.serializers import ProductFullSerializer
 from open_prices.api.proofs.serializers import ProofSerializer
+from open_prices.locations.models import Location
 from open_prices.prices.models import Price
+from open_prices.products.models import Product
 from open_prices.proofs.models import Proof
 
 
-class PriceFullSerializer(serializers.ModelSerializer):
-    product = ProductFullSerializer()
-    location = LocationFullSerializer()
-    proof = ProofSerializer()
+class PriceSerializer(serializers.ModelSerializer):
+    product_id = serializers.PrimaryKeyRelatedField(
+        queryset=Product.objects.all(), source="product"
+    )
+    location_id = serializers.PrimaryKeyRelatedField(
+        queryset=Location.objects.all(), source="location"
+    )
+    proof_id = serializers.PrimaryKeyRelatedField(
+        queryset=Proof.objects.all(), source="proof"
+    )
 
     class Meta:
         model = Price
         # fields = "__all__"
         exclude = ["source"]
+
+
+class PriceFullSerializer(PriceSerializer):
+    product = ProductFullSerializer()
+    location = LocationSerializer()
+    proof = ProofSerializer()
+
+    class Meta:
+        model = Price
+        exclude = PriceSerializer.Meta.exclude
 
 
 class PriceCreateSerializer(serializers.ModelSerializer):

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -211,7 +211,7 @@ class PriceCreateApiTest(TestCase):
         self.assertEqual(response.data["product"]["code"], "8001505005707")
         self.assertEqual(response.data["location"]["osm_id"], 652825274)
         p = Price.objects.last()
-        self.assertIsNone(p.source)  # ignored
+        self.assertEqual(p.source, "API")  # default value
 
     def test_price_create_with_app_name(self):
         for app_name in ["", "test app"]:

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -158,6 +158,24 @@ class PriceCreateApiTest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 403)
+        # proof_id field missing
+        data = self.data.copy()
+        del data["proof_id"]
+        response = self.client.post(
+            self.url,
+            data,
+            headers={"Authorization": f"Bearer {self.user_session.token}"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        # empty proof
+        response = self.client.post(
+            self.url,
+            {**self.data, "proof_id": None},
+            headers={"Authorization": f"Bearer {self.user_session.token}"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
         # unknown proof
         response = self.client.post(
             self.url,
@@ -194,8 +212,9 @@ class PriceCreateApiTest(TestCase):
         self.assertEqual(response.data["location"]["osm_id"], 652825274)
         p = Price.objects.last()
         self.assertIsNone(p.source)  # ignored
+
+    def test_price_create_with_app_name(self):
         for app_name in ["", "test app"]:
-            # with empty app_name
             response = self.client.post(
                 self.url + f"?app_name={app_name}",
                 self.data,

--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -45,7 +45,6 @@ class PriceViewSet(
         return self.serializer_class
 
     def perform_create(self, serializer):
-        print("price perform_create", serializer.validated_data)
         return serializer.save(owner=self.request.user.user_id, source=self.source)
 
     def create(self, request: Request, *args, **kwargs):

--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -52,7 +52,7 @@ class PriceViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         # get source
-        self.source = self.request.GET.get("app_name", None)
+        self.source = self.request.GET.get("app_name", "API")
         # save
         price = self.perform_create(serializer)
         # return full price

--- a/open_prices/api/proofs/serializers.py
+++ b/open_prices/api/proofs/serializers.py
@@ -1,23 +1,27 @@
 from rest_framework import serializers
 
-from open_prices.api.locations.serializers import LocationFullSerializer
+from open_prices.api.locations.serializers import LocationSerializer
+from open_prices.locations.models import Location
 from open_prices.proofs.models import Proof
 
 
-class ProofFullSerializer(serializers.ModelSerializer):
-    location = LocationFullSerializer()
-
-    class Meta:
-        model = Proof
-        # fields = "__all__"
-        exclude = ["source"]
-
-
 class ProofSerializer(serializers.ModelSerializer):
+    location_id = serializers.PrimaryKeyRelatedField(
+        queryset=Location.objects.all(), source="location"
+    )
+
     class Meta:
         model = Proof
         # fields = "__all__"
         exclude = ["source"]
+
+
+class ProofFullSerializer(ProofSerializer):
+    location = LocationSerializer()
+
+    class Meta:
+        model = Proof
+        exclude = ProofSerializer.Meta.exclude
 
 
 class ProofCreateSerializer(serializers.ModelSerializer):

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -73,30 +73,30 @@ class ProofCreateApiTest(TestCase):
     def setUpTestData(cls):
         cls.url = reverse("api:proofs-upload")
         cls.user_session = SessionFactory()
-        # cls.data = {}
-
-    def test_proof_create(self):
-        data = {
-            "file": open("filename.webp", "rb"),
+        cls.data = {
+            # "file": open("filename.webp", "rb"),
             "type": proof_constants.TYPE_RECEIPT,
             "currency": "EUR",
             "price_count": 15,
             "source": "test",
         }
+
+    def test_proof_create(self):
+        self.data["file"] = open("filename.webp", "rb")
         # anonymous
-        response = self.client.post(self.url, data)
+        response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, 403)
         # wrong token
         response = self.client.post(
             self.url,
-            data,
+            self.data,
             headers={"Authorization": f"Bearer {self.user_session.token}X"},
         )
         self.assertEqual(response.status_code, 403)
         # authenticated
         response = self.client.post(
             self.url,
-            data,
+            self.data,
             headers={"Authorization": f"Bearer {self.user_session.token}"},
         )
         self.assertEqual(response.status_code, 201)
@@ -106,11 +106,14 @@ class ProofCreateApiTest(TestCase):
         self.assertTrue("source" not in response.data)
         p = Proof.objects.last()
         self.assertIsNone(p.source)  # ignored
+
+    def test_proof_create_with_app_name(self):
+        self.data["file"] = open("filename.webp", "rb")
         for app_name in ["", "test app"]:
             # with empty app_name
             response = self.client.post(
                 self.url + f"?app_name={app_name}",
-                data,
+                self.data,
                 headers={"Authorization": f"Bearer {self.user_session.token}"},
             )
             self.assertEqual(response.status_code, 201)

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -105,7 +105,7 @@ class ProofCreateApiTest(TestCase):
         self.assertEqual(response.data["owner"], self.user_session.user.user_id)
         self.assertTrue("source" not in response.data)
         p = Proof.objects.last()
-        self.assertIsNone(p.source)  # ignored
+        self.assertEqual(p.source, "API")  # default value
 
     def test_proof_create_with_app_name(self):
         self.data["file"] = open("filename.webp", "rb")

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -64,7 +64,7 @@ class ProofViewSet(
         serializer = ProofCreateSerializer(data=proof_create_data)
         serializer.is_valid(raise_exception=True)
         # get source
-        self.source = self.request.GET.get("app_name", None)
+        self.source = self.request.GET.get("app_name", "API")
         # save
         proof = serializer.save(owner=self.request.user.user_id, source=self.source)
         # return full proof


### PR DESCRIPTION
### What

- Price : add tests to check that the `proof_id` is passed
- Price & Proof : pass the FK ids in the readonly serializers
- source from `app_name` param : set a default value (`API`)
