### PR TITLE
feat(Django): CORS configuration (allow all)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -29,6 +29,7 @@ DJANGO_APPS = [
 ]
 
 THIRD_PARTY_APPS = [
+    "corsheaders",  # django-cors-headers
     "rest_framework",  # djangorestframework
     "django_filters",  # django-filter
     "drf_spectacular",  # drf-spectacular
@@ -53,6 +54,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -139,6 +141,13 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+
+# Security
+# ------------------------------------------------------------------------------
+
+CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_CREDENTIALS = True
 
 
 # Django REST Framework (DRF) & django-filters & drf-spectacular

--- a/poetry.lock
+++ b/poetry.lock
@@ -565,6 +565,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.4.0"
+description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_cors_headers-4.4.0-py3-none-any.whl", hash = "sha256:5c6e3b7fe870876a1efdfeb4f433782c3524078fa0dc9e0195f6706ce7a242f6"},
+    {file = "django_cors_headers-4.4.0.tar.gz", hash = "sha256:92cf4633e22af67a230a1456cb1b7a02bb213d6536d2dcb2a4a24092ea9cebc2"},
+]
+
+[package.dependencies]
+asgiref = ">=3.6"
+django = ">=3.2"
+
+[[package]]
 name = "django-debug-toolbar"
 version = "4.4.6"
 description = "A configurable set of panels that display various debug information about the current request/response."
@@ -3306,4 +3321,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "3f07d33dcf96837262464bf3d0d9a7e2e64e6ade12f9dbe49f127b6bb6fb546f"
+content-hash = "1762c90d8f9e60e073be2e1bb4f53c1135476487202ee6775ad40325bbb4c959"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ django-q2 = "^1.6.2"
 croniter = "^3.0.3"
 blessed = "^1.20.0"
 ipython = "^8.26.0"
+django-cors-headers = "^4.4.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "~23.12.1"


### PR DESCRIPTION
### What

Setup [django-cors-headers](https://github.com/adamchainz/django-cors-headers) to allow API calls from anywhere (official frontend, or mobile, or external services)
