### PR TITLE
fix(Django): last API fixes

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -162,7 +162,7 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "open_prices.common.middleware.custom_exception_handler",
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "ORDERING_PARAM": "order_by",
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "DEFAULT_PAGINATION_CLASS": "open_prices.api.pagination.CustomPagination",
     "PAGE_SIZE": 100,
     "COERCE_DECIMAL_TO_STRING": False,
 }

--- a/open_prices/api/auth/views.py
+++ b/open_prices/api/auth/views.py
@@ -25,7 +25,7 @@ from open_prices.users.utils import get_or_create_session
 class LoginView(APIView):
     serializer_class = LoginSerializer
 
-    @extend_schema(responses=SessionResponseSerializer)
+    @extend_schema(responses=SessionResponseSerializer, tags=["auth"])
     def post(self, request: Request) -> Response:
         """
         Authentication: provide username/password
@@ -85,6 +85,7 @@ class SessionView(APIView):
     permission_classes = [IsAuthenticated]
     serializer_class = SessionFullSerializer
 
+    @extend_schema(tags=["auth"])
     def get(self, request: Request) -> Response:
         session = get_request_session(request)
         return Response(
@@ -96,6 +97,7 @@ class SessionView(APIView):
             }
         )
 
+    @extend_schema(tags=["auth"])
     def delete(self, request: Request) -> Response:
         session = get_request_session(request)
         session.delete()

--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -20,9 +20,9 @@ class LocationListApiTest(TestCase):
     def test_location_list(self):
         # anonymous
         response = self.client.get(self.url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(len(response.data["results"]), 3)
-        self.assertTrue("id" in response.data["results"][0])
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(len(response.data["items"]), 3)
+        self.assertTrue("id" in response.data["items"][0])
 
 
 class LocationListFilterApiTest(TestCase):
@@ -41,30 +41,30 @@ class LocationListFilterApiTest(TestCase):
     def test_location_list_order_by(self):
         url = reverse("api:locations-list") + "?order_by=-price_count"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(response.data["results"][0]["price_count"], 50)
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(response.data["items"][0]["price_count"], 50)
 
     def test_location_list_filter_by_osm_name(self):
         url = reverse("api:locations-list") + "?osm_name__like=monop"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["osm_name"], "Monoprix")
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["osm_name"], "Monoprix")
 
     def test_location_list_filter_by_price_count(self):
         # exact price_count
         url = reverse("api:locations-list") + "?price_count=15"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price_count"], 15)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price_count"], 15)
         # lte / gte
         url = reverse("api:locations-list") + "?price_count__gte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price_count"], 50)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price_count"], 50)
         url = reverse("api:locations-list") + "?price_count__lte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["price_count"], 15)
+        self.assertEqual(response.data["total"], 2)
+        self.assertEqual(response.data["items"][0]["price_count"], 15)
 
 
 class LocationDetailApiTest(TestCase):

--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -1,0 +1,23 @@
+from rest_framework import pagination
+from rest_framework.response import Response
+
+
+class CustomPagination(pagination.PageNumberPagination):
+    """
+    https://www.django-rest-framework.org/api-guide/pagination/#custom-pagination-styles
+    - results -> items
+    - count -> total
+    - next -> ?
+    - previous -> ?
+    """
+
+    def get_paginated_response(self, data):
+        return Response(
+            {
+                "items": data,
+                "page": self.page.number,
+                "pages": self.page.paginator.num_pages,
+                "size": self.page.paginator.per_page,
+                "total": self.page.paginator.count,
+            }
+        )

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -27,9 +27,9 @@ class PriceListApiTest(TestCase):
     def test_price_list(self):
         # anonymous
         response = self.client.get(self.url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(len(response.data["results"]), 3)
-        self.assertTrue("id" in response.data["results"][0])
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(len(response.data["items"]), 3)
+        self.assertTrue("id" in response.data["items"][0])
 
 
 class PriceListFilterApiTest(TestCase):
@@ -48,57 +48,57 @@ class PriceListFilterApiTest(TestCase):
     def test_price_list_order_by(self):
         url = reverse("api:prices-list") + "?order_by=-price"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(response.data["results"][0]["price"], 50.00)
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(response.data["items"][0]["price"], 50.00)
 
     def test_price_list_filter_by_product_code(self):
         url = reverse("api:prices-list") + "?product_code=8001505005707"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["total"], 1)
 
     def test_price_list_filter_by_price(self):
         # exact price
         url = reverse("api:prices-list") + "?price=15"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price"], 15.00)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price"], 15.00)
         # lte / gte
         url = reverse("api:prices-list") + "?price__gte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price"], 50.00)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price"], 50.00)
         url = reverse("api:prices-list") + "?price__lte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["price"], 15.00)
+        self.assertEqual(response.data["total"], 2)
+        self.assertEqual(response.data["items"][0]["price"], 15.00)
 
     def test_price_list_filter_by_currency(self):
         url = reverse("api:prices-list") + "?currency=EUR"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(response.data["total"], 2)
 
     def test_price_list_filter_by_date(self):
         # exact date
         url = reverse("api:prices-list") + "?date=2024-01-01"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["total"], 1)
         # lte / gte
         url = reverse("api:prices-list") + "?date__gte=2024-01-01"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(response.data["total"], 2)
         # month
         url = reverse("api:prices-list") + "?date__month=1"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["total"], 1)
         # year
         url = reverse("api:prices-list") + "?date__year=2024"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(response.data["total"], 2)
 
     def test_price_list_filter_by_owner(self):
         url = reverse("api:prices-list") + "?owner=user_1"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(response.data["total"], 2)
 
 
 class PriceDetailApiTest(TestCase):

--- a/open_prices/api/products/tests.py
+++ b/open_prices/api/products/tests.py
@@ -15,9 +15,9 @@ class ProductListApiTest(TestCase):
     def test_product_list(self):
         # anonymous
         response = self.client.get(self.url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(len(response.data["results"]), 3)
-        self.assertTrue("id" in response.data["results"][0])
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(len(response.data["items"]), 3)
+        self.assertTrue("id" in response.data["items"][0])
 
 
 class ProductListFilterApiTest(TestCase):
@@ -34,38 +34,38 @@ class ProductListFilterApiTest(TestCase):
     def test_product_list_order_by(self):
         url = reverse("api:products-list") + "?order_by=-price_count"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 3)
-        self.assertEqual(response.data["results"][0]["price_count"], 50)
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(response.data["items"][0]["price_count"], 50)
 
     def test_product_list_filter_by_code(self):
         url = reverse("api:products-list") + "?code=8001505005707"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["code"], "8001505005707")
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["code"], "8001505005707")
 
     def test_product_list_filter_by_product_name(self):
         url = reverse("api:products-list") + "?product_name__like=rice"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["total"], 1)
         self.assertEqual(
-            response.data["results"][0]["product_name"], "Vitariz Rice Drink"
+            response.data["items"][0]["product_name"], "Vitariz Rice Drink"
         )
 
     def test_product_list_filter_by_price_count(self):
         # exact price_count
         url = reverse("api:products-list") + "?price_count=15"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price_count"], 15)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price_count"], 15)
         # lte / gte
         url = reverse("api:products-list") + "?price_count__gte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price_count"], 50)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price_count"], 50)
         url = reverse("api:products-list") + "?price_count__lte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["price_count"], 15)
+        self.assertEqual(response.data["total"], 2)
+        self.assertEqual(response.data["items"][0]["price_count"], 15)
 
 
 class ProductDetailApiTest(TestCase):

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -30,9 +30,9 @@ class ProofListApiTest(TestCase):
             self.url, headers={"Authorization": f"Bearer {self.user_session.token}"}
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(len(response.data["results"]), 1)
-        self.assertEqual(response.data["results"][0]["id"], self.proof.id)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["items"][0]["id"], self.proof.id)
 
 
 class ProofDetailApiTest(TestCase):

--- a/open_prices/api/urls.py
+++ b/open_prices/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import path
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
@@ -6,6 +6,7 @@ from drf_spectacular.views import (
 )
 from rest_framework import routers
 
+from open_prices.api.auth.views import LoginView, SessionView
 from open_prices.api.locations.views import LocationViewSet
 from open_prices.api.prices.views import PriceViewSet
 from open_prices.api.products.views import ProductViewSet
@@ -23,7 +24,9 @@ router.register(r"v1/proofs", ProofViewSet, basename="proofs")
 router.register(r"v1/prices", PriceViewSet, basename="prices")
 
 urlpatterns = [
-    path("v1/auth/", include("open_prices.api.auth.urls")),
+    # auth urls
+    path("v1/auth", LoginView.as_view(), name="login"),
+    path("v1/session", SessionView.as_view(), name="session"),
     # health check
     path("status", StatusView.as_view(), name="status"),
     # Swagger / OpenAPI documentation

--- a/open_prices/api/users/tests.py
+++ b/open_prices/api/users/tests.py
@@ -16,11 +16,11 @@ class UserListApiTest(TestCase):
     def test_user_list(self):
         # anonymous
         response = self.client.get(self.url)
-        self.assertEqual(response.data["count"], 2)
-        self.assertEqual(len(response.data["results"]), 2)
-        self.assertFalse("id" in response.data["results"][0])
+        self.assertEqual(response.data["total"], 2)
+        self.assertEqual(len(response.data["items"]), 2)
+        self.assertFalse("id" in response.data["items"][0])
         for field_name in User.SERIALIZED_FIELDS:
-            self.assertTrue(field_name in response.data["results"][0])
+            self.assertTrue(field_name in response.data["items"][0])
 
 
 class UserListFilterApiTest(TestCase):
@@ -33,21 +33,21 @@ class UserListFilterApiTest(TestCase):
     def test_user_list_order_by(self):
         url = reverse("api:users-list") + "?order_by=-price_count"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 2)
-        self.assertEqual(response.data["results"][0]["price_count"], 50)
+        self.assertEqual(response.data["total"], 2)
+        self.assertEqual(response.data["items"][0]["price_count"], 50)
 
     def test_user_list_filter_by_price_count(self):
         # exact price_count
         url = reverse("api:users-list") + "?price_count=15"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price_count"], 15)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price_count"], 15)
         # lte / gte
         url = reverse("api:users-list") + "?price_count__gte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price_count"], 50)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price_count"], 50)
         url = reverse("api:users-list") + "?price_count__lte=20"
         response = self.client.get(url)
-        self.assertEqual(response.data["count"], 1)
-        self.assertEqual(response.data["results"][0]["price_count"], 15)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["price_count"], 15)

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -21,10 +21,10 @@ OFF_FIELDS = [
     "product_name",
     "product_quantity",
     "product_quantity_unit",
-    # "categories_tags",
+    "categories_tags",
     "brands",
-    # "brands_tags",
-    # "labels_tags",
+    "brands_tags",
+    "labels_tags",
     "image_url",
     "nutriscore_grade",
     "ecoscore_grade",
@@ -51,16 +51,6 @@ def normalize_product_fields(product: JSONType) -> JSONType:
         # If the product quantity is too high, it's probably an
         # error, and may cause an OutOfRangeError in the database
         product["product_quantity"] = None
-
-    # Some products have null unique_scans_n
-    if product.get("unique_scans_n") is None:
-        product["unique_scans_n"] = 0
-
-    for key in ("categories_tags", "labels_tags", "brands_tags"):
-        if key in product and product[key] is None:
-            # Set the field to an empty list if it's None
-            product[key] = []
-
     return product
 
 

--- a/open_prices/locations/models.py
+++ b/open_prices/locations/models.py
@@ -47,6 +47,15 @@ class Location(models.Model):
         verbose_name = "Location"
         verbose_name_plural = "Locations"
 
+    def truncate_lat_lon(self):
+        for field_name in self.LAT_LON_DECIMAL_FIELDS:
+            if getattr(self, field_name) is not None:
+                setattr(
+                    self,
+                    field_name,
+                    truncate_decimal(getattr(self, field_name), max_decimal_places=7),
+                )
+
     def clean(self, *args, **kwargs):
         # dict to store all ValidationErrors
         validation_errors = dict()
@@ -73,13 +82,7 @@ class Location(models.Model):
         - truncate decimal fields
         - run validations
         """
-        for field_name in self.LAT_LON_DECIMAL_FIELDS:
-            if getattr(self, field_name) is not None:
-                setattr(
-                    self,
-                    field_name,
-                    truncate_decimal(getattr(self, field_name), max_decimal_places=7),
-                )
+        self.truncate_lat_lon()
         self.full_clean()
         super().save(*args, **kwargs)
 

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -18,6 +18,7 @@ from open_prices.products.models import (
 from open_prices.proofs.factories import ProofFactory
 from open_prices.proofs.models import Proof
 from open_prices.users.factories import SessionFactory
+from open_prices.users.models import User
 
 
 class PriceModelSaveTest(TestCase):
@@ -318,6 +319,9 @@ class PriceModelSaveTest(TestCase):
             product_code=product.code,
             owner=user_session.user.user_id,
         )
+        self.assertEqual(
+            User.objects.get(user_id=user_session.user.user_id).price_count, 1
+        )
         self.assertEqual(Proof.objects.get(id=user_proof_1.id).price_count, 1)
         self.assertEqual(Location.objects.get(id=location.id).price_count, 1)
         self.assertEqual(Product.objects.get(id=product.id).price_count, 1)
@@ -327,6 +331,9 @@ class PriceModelSaveTest(TestCase):
             location_osm_type=location.osm_type,
             product_code=product.code,
             owner=user_session.user.user_id,
+        )
+        self.assertEqual(
+            User.objects.get(user_id=user_session.user.user_id).price_count, 2
         )
         self.assertEqual(Proof.objects.get(id=user_proof_2.id).price_count, 1)
         self.assertEqual(Location.objects.get(id=location.id).price_count, 2)
@@ -346,10 +353,16 @@ class PriceModelDeleteTest(TestCase):
             product_code=product.code,
             owner=user_session.user.user_id,
         )
+        self.assertEqual(
+            User.objects.get(user_id=user_session.user.user_id).price_count, 1
+        )
         self.assertEqual(Proof.objects.get(id=user_proof.id).price_count, 1)
         self.assertEqual(Location.objects.get(id=location.id).price_count, 1)
         self.assertEqual(Product.objects.get(id=product.id).price_count, 1)
         price.delete()
+        self.assertEqual(
+            User.objects.get(user_id=user_session.user.user_id).price_count, 0
+        )
         self.assertEqual(Proof.objects.get(id=user_proof.id).price_count, 0)
         self.assertEqual(Location.objects.get(id=location.id).price_count, 0)
         self.assertEqual(Product.objects.get(id=product.id).price_count, 0)

--- a/open_prices/products/tests.py
+++ b/open_prices/products/tests.py
@@ -60,5 +60,7 @@ class ProductModelSaveTest(TransactionTestCase):
         ProductFactory(code="0123456789103", categories_tags=None)
         ProductFactory(code="0123456789104", categories_tags=[])
         ProductFactory(code="0123456789105", categories_tags=["test"])
+        # unique_scan_n
+        ProductFactory(code="0123456789106", unique_scans_n=None)
         # full OFF object
         ProductFactory(**PRODUCT_OFF)

--- a/open_prices/users/factories.py
+++ b/open_prices/users/factories.py
@@ -1,5 +1,3 @@
-import random
-
 import factory
 import factory.fuzzy
 from factory.django import DjangoModelFactory
@@ -13,7 +11,7 @@ class UserFactory(DjangoModelFactory):
         model = User
 
     user_id = factory.Faker("user_name")
-    price_count = factory.LazyAttribute(lambda x: random.randrange(0, 100))
+    # price_count = factory.LazyAttribute(lambda x: random.randrange(0, 100))
 
 
 class SessionFactory(DjangoModelFactory):


### PR DESCRIPTION
### What

Last fixes to match with the existing FastAPI backend
- rename paginator dict keys
- rename auth urls
- increment User.price_count on price create (and decrement on price delete) - #377
- manage product ArrayFields (instead of JsonField)