### PR TITLE
perf(Django): Use select_related to avoid N+1 queries

### DIFF
--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -35,11 +35,12 @@ class PriceListApiTest(TestCase):
 
     def test_price_list(self):
         # anonymous
-        response = self.client.get(self.url)
-        self.assertEqual(response.data["total"], 3)
-        self.assertEqual(len(response.data["items"]), 3)
-        self.assertTrue("id" in response.data["items"][0])
-        self.assertEqual(response.data["items"][0]["price"], 15.00)  # default order
+        with self.assertNumQueries(1 + 1):  # thanks to select_related
+            response = self.client.get(self.url)
+            self.assertEqual(response.data["total"], 3)
+            self.assertEqual(len(response.data["items"]), 3)
+            self.assertTrue("id" in response.data["items"][0])
+            self.assertEqual(response.data["items"][0]["price"], 15.00)  # default order
 
 
 class PriceListPaginationApiTest(TestCase):

--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -32,7 +32,9 @@ class PriceViewSet(
     ordering = ["created"]
 
     def get_queryset(self):
-        if self.request.method in ["PATCH", "DELETE"]:
+        if self.request.method in ["GET"]:
+            return self.queryset.select_related("product", "location", "proof")
+        elif self.request.method in ["PATCH", "DELETE"]:
             # only return prices owned by the current user
             if self.request.user.is_authenticated:
                 return Price.objects.filter(owner=self.request.user.user_id)

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -38,7 +38,10 @@ class ProofViewSet(
     def get_queryset(self):
         # only return proofs owned by the current user
         if self.request.user.is_authenticated:
-            return Proof.objects.filter(owner=self.request.user.user_id)
+            queryset = Proof.objects.filter(owner=self.request.user.user_id)
+            if self.request.method in ["GET"]:
+                return queryset.select_related("location")
+            return queryset
         return self.queryset
 
     def get_serializer_class(self):


### PR DESCRIPTION
### What

On both Price GET & Proof GET, add [`select_related`](https://docs.djangoproject.com/en/5.1/ref/models/querysets/#select-related) to avoid N+1 queries


