### PR TITLE
chore: fix static configuration

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -159,6 +159,8 @@ jobs:
           make migrate-db
           # Launch new version
           make up
+          # copy static files so they can be served by nginx
+          make cp-static-files
 
     - name: Check services are up
       uses: appleboy/ssh-action@master

--- a/Makefile
+++ b/Makefile
@@ -148,12 +148,15 @@ create_external_volumes:
 	docker volume create open_prices_images
 	docker volume create open_prices_data-dump
 
+cp-static-files:
+	@echo "🥫 Copying static files from api container to the host …"
+	docker cp open_prices-api-1:/opt/open-prices/static www/
 
-# TODO: update to Django migrate command
 migrate-db:
 	@echo "🥫 Migrating database …"
 	${DOCKER_COMPOSE} run --rm --no-deps api python3 manage.py migrate
 
+# TODO: migrate to Django
 add-db-revision: guard-message
 	${DOCKER_COMPOSE} run --rm --no-deps api alembic revision --autogenerate -m "${message}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - images:/opt/open-prices/img
       - data-dump:/opt/open-prices/data
       - home_cache:/home/off/.cache
-      - ./static:/opt/open-prices/static
     depends_on:
       - postgres
 
@@ -60,8 +59,6 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf
       # Mount the static files (for index & vue.js app)
       - ./www:/var/www
-      # Mount the Django staticfiles
-      - ./static:/var/static
       # Mount the images
       - images:/var/img
       # And the dir where the daily data dump is stored

--- a/nginx.conf
+++ b/nginx.conf
@@ -83,10 +83,6 @@ http {
             }
         }
 
-        location /static/ {
-            root /var;
-        }
-
         location /img {
             alias /var/img;
 


### PR DESCRIPTION
When static files change, we run automatically `make cp-static-files` in production.