### PR TITLE
fix(Django): improve some API returns

### DIFF
--- a/open_prices/api/auth/views.py
+++ b/open_prices/api/auth/views.py
@@ -44,7 +44,7 @@ class LoginView(APIView):
         """
         if not settings.OAUTH2_SERVER_URL:
             return Response(
-                {"error": "OAUTH2_SERVER_URL environment variable missing"},
+                {"detail": "OAUTH2_SERVER_URL environment variable missing"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
         # By specifying body=1, information about the user is returned in the
@@ -70,12 +70,12 @@ class LoginView(APIView):
         elif response.status_code == 403:
             time.sleep(2)  # prevents brute-force
             return Response(
-                {"error": "Invalid authentication credentials"},
+                {"detail": "Invalid authentication credentials"},
                 status=status.HTTP_401_UNAUTHORIZED,
                 headers={"WWW-Authenticate": "Bearer"},
             )
         raise Response(
-            {"error": "Server error"},
+            {"detail": "Server error"},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 

--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -104,6 +104,9 @@ class LocationDetailApiTest(TestCase):
         url = reverse("api:locations-detail", args=[999])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.data["detail"], "No Location matches the given query."
+        )
         # existing location
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
@@ -115,6 +118,9 @@ class LocationDetailApiTest(TestCase):
         url = reverse("api:locations-get-by-osm", args=["NODE", 999])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.data["detail"], "No Location matches the given query."
+        )
         # existing location
         url = reverse(
             "api:locations-get-by-osm",

--- a/open_prices/api/locations/views.py
+++ b/open_prices/api/locations/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, mixins, status, viewsets
 from rest_framework.decorators import action
@@ -10,6 +9,7 @@ from open_prices.api.locations.serializers import (
     LocationCreateSerializer,
     LocationSerializer,
 )
+from open_prices.api.utils import get_object_or_drf_404
 from open_prices.locations.models import Location
 
 
@@ -49,6 +49,6 @@ class LocationViewSet(
         detail=False, methods=["GET"], url_path=r"osm/(?P<osm_type>\w+)/(?P<osm_id>\d+)"
     )
     def get_by_osm(self, request, osm_type, osm_id):
-        location = get_object_or_404(Location, osm_type=osm_type, osm_id=osm_id)
+        location = get_object_or_drf_404(Location, osm_type=osm_type, osm_id=osm_id)
         serializer = self.get_serializer(location)
         return Response(serializer.data)

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -256,6 +256,7 @@ class PriceDetailApiTest(TestCase):
         url = reverse("api:prices-detail", args=[999])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "No Price matches the given query.")
         # existing price
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)

--- a/open_prices/api/products/tests.py
+++ b/open_prices/api/products/tests.py
@@ -118,6 +118,7 @@ class ProductDetailApiTest(TestCase):
         url = reverse("api:products-detail", args=[999])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "No Product matches the given query.")
         # existing product
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
@@ -128,6 +129,7 @@ class ProductDetailApiTest(TestCase):
         url = reverse("api:products-get-by-code", args=[999])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "No Product matches the given query.")
         # existing product
         url = reverse("api:products-get-by-code", args=[self.product.code])
         response = self.client.get(url)

--- a/open_prices/api/products/views.py
+++ b/open_prices/api/products/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, mixins, viewsets
 from rest_framework.decorators import action
@@ -7,6 +6,7 @@ from rest_framework.response import Response
 
 from open_prices.api.products.filters import ProductFilter
 from open_prices.api.products.serializers import ProductFullSerializer
+from open_prices.api.utils import get_object_or_drf_404
 from open_prices.products.models import Product
 
 
@@ -22,6 +22,6 @@ class ProductViewSet(
 
     @action(detail=False, methods=["GET"], url_path=r"code/(?P<code>\d+)")
     def get_by_code(self, request: Request, code):
-        product = get_object_or_404(Product, code=code)
+        product = get_object_or_drf_404(Product, code=code)
         serializer = self.get_serializer(product)
         return Response(serializer.data)

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -130,6 +130,7 @@ class ProofDetailApiTest(TestCase):
             url, headers={"Authorization": f"Bearer {self.user_session_1.token}"}
         )
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "No Proof matches the given query.")
         # anonymous
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 403)

--- a/open_prices/api/utils.py
+++ b/open_prices/api/utils.py
@@ -1,0 +1,8 @@
+from django.http import Http404
+
+
+def get_object_or_drf_404(model, **kwargs):
+    try:
+        return model.objects.get(**kwargs)
+    except model.DoesNotExist:
+        raise Http404(f"No {model._meta.verbose_name} matches the given query.")


### PR DESCRIPTION
### What

|Endpoint|Expected|Done ?|
|--|---|---|
|GET Location by osm id & type|Should return a JSON-formatted 404 + improve message|yes|
|GET Product by code|Should return a JSON-formatted 404 + improve message|yes|
|Auth|If error, return "detail" instead of "error"|yes|