### PR TITLE
refactor(stats): new model update_price_count() methods

### DIFF
--- a/open_prices/locations/models.py
+++ b/open_prices/locations/models.py
@@ -97,9 +97,13 @@ class Location(models.Model):
         self.full_clean()
         super().save(*args, **kwargs)
 
+    def update_price_count(self):
+        self.price_count = self.prices.count()
+        self.save(update_fields=["price_count"])
+
 
 @receiver(signals.post_save, sender=Location)
-def location_post_create_fetch_data_from_openstreetmap(
+def location_post_create_fetch_and_save_data_from_openstreetmap(
     sender, instance, created, **kwargs
 ):
     if not settings.TESTING:

--- a/open_prices/products/models.py
+++ b/open_prices/products/models.py
@@ -70,6 +70,10 @@ class Product(models.Model):
         self.full_clean()
         super().save(*args, **kwargs)
 
+    def update_price_count(self):
+        self.price_count = self.prices.count()
+        self.save(update_fields=["price_count"])
+
 
 @receiver(signals.post_save, sender=Product)
 def product_post_create_fetch_and_save_data_from_openfoodfacts(

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -119,7 +119,6 @@ class Proof(models.Model):
             location, created = Location.objects.get_or_create(
                 osm_id=self.location_osm_id,
                 osm_type=self.location_osm_type,
-                # defaults={"proof_count": 1},
             )
             self.location = location
 
@@ -128,3 +127,7 @@ class Proof(models.Model):
         if not self.id:
             self.set_location()
         super().save(*args, **kwargs)
+
+    def update_price_count(self):
+        self.price_count = self.prices.count()
+        self.save(update_fields=["price_count"])

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -65,3 +65,21 @@ class ProofQuerySetTest(TestCase):
         proof = Proof.objects.with_stats().get(id=self.proof_with_price.id)
         self.assertEqual(proof.price_count_annotated, 1)
         self.assertEqual(proof.price_count, 1)
+
+
+class ProofPropertyTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.proof = ProofFactory()
+        PriceFactory(proof_id=cls.proof.id, price=1.0)
+        PriceFactory(proof_id=cls.proof.id, price=2.0)
+
+    def test_update_price_count(self):
+        self.proof.refresh_from_db()
+        self.assertEqual(self.proof.price_count, 2)
+        # bulk delete prices to skip signals
+        self.proof.prices.all().delete()
+        self.assertEqual(self.proof.price_count, 2)  # should be 0
+        # update_price_count() should fix price_count
+        self.proof.update_price_count()
+        self.assertEqual(self.proof.price_count, 0)

--- a/open_prices/users/models.py
+++ b/open_prices/users/models.py
@@ -30,6 +30,12 @@ class User(models.Model):
     def is_authenticated(self):
         return True
 
+    def update_price_count(self):
+        from open_prices.prices.models import Price
+
+        self.price_count = Price.objects.filter(owner=self).count()
+        self.save(update_fields=["price_count"])
+
 
 class Session(models.Model):
     user = models.ForeignKey(

--- a/open_prices/users/tests.py
+++ b/open_prices/users/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from open_prices.prices.factories import PriceFactory
+from open_prices.prices.models import Price
 from open_prices.users.factories import UserFactory
 from open_prices.users.models import User
 
@@ -14,3 +15,21 @@ class UserQuerySetTest(TestCase):
 
     def test_has_prices(self):
         self.assertEqual(User.objects.has_prices().count(), 1)
+
+
+class UserPropertyTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        PriceFactory(owner=cls.user.user_id, price=1.0)
+        PriceFactory(owner=cls.user.user_id, price=2.0)
+
+    def test_update_price_count(self):
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.price_count, 2)
+        # bulk delete prices to skip signals
+        Price.objects.filter(owner=self.user).delete()
+        self.assertEqual(self.user.price_count, 2)  # should be 0
+        # update_price_count() should fix price_count
+        self.user.update_price_count()
+        self.assertEqual(self.user.price_count, 0)


### PR DESCRIPTION
### What

For the models with a `price_count` field (Product, Location, Proof, User), we add a `update_price_count` helper.
Will be useful for afterwards
