### PR TITLE
refactor(Proofs): Methods to update missing proof fields from prices

### DIFF
--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -84,6 +84,17 @@ def update_location_counts_task():
             getattr(location, f"update_{field}")()
 
 
+def fix_proof_fields_task():
+    """
+    Proofs uploaded via the (old) mobile app lack location/date/currency fields
+    Fix these fields using the proof's prices
+    """
+    for proof in Proof.objects.filter(price_count__gte=1, location=None):
+        proof.set_missing_location_from_prices()
+        proof.set_missing_date_from_prices()
+        proof.set_missing_currency_from_prices()
+
+
 def dump_db_task():
     """
     Dump the database as JSONL files to the data directory
@@ -105,6 +116,7 @@ CRON_SCHEDULES = {
     "import_opf_db_task": "20 15 * * *",  # daily at 15:20
     "import_off_db_task": "30 15 * * *",  # daily at 15:30
     "update_total_stats_task": "0 1 * * *",  # daily at 01:00
+    "fix_proof_fields_task": "10 1 * * *",  # daily at 01:10
     "update_user_counts_task": "0 2 * * 1",  # every start of the week
     "update_location_counts_task": "10 2 * * 1",  # every start of the week
     "update_product_counts_task": "20 2 * * 1",  # every start of the week

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -177,3 +177,53 @@ class Proof(models.Model):
             old_location.update_price_count()
         if new_location:
             new_location.update_price_count()
+
+    def set_missing_location_from_prices(self):
+        if self.is_type_single_shop and not self.location and self.prices.exists():
+            proof_prices_location_list = list(
+                self.prices.values_list("location", flat=True).distinct()
+            )
+            if len(proof_prices_location_list) == 1:
+                location = self.prices.first().location
+                self.location_osm_id = location.osm_id
+                self.location_osm_type = location.osm_type
+                self.save()
+            else:
+                print(
+                    "different locations",
+                    self,
+                    self.prices.count(),
+                    proof_prices_location_list,
+                )
+
+    def set_missing_date_from_prices(self):
+        if self.is_type_single_shop and not self.date and self.prices.exists():
+            proof_prices_dates_list = list(
+                self.prices.values_list("date", flat=True).distinct()
+            )
+            if len(proof_prices_dates_list) == 1:
+                self.date = self.prices.first().date
+                self.save()
+            else:
+                print(
+                    "different dates",
+                    self,
+                    self.prices.count(),
+                    proof_prices_dates_list,
+                )
+
+    def set_missing_currency_from_prices(self):
+        if self.is_type_single_shop and not self.currency and self.prices.exists():
+            proof_prices_currencies_list = list(
+                self.prices.values_list("currency", flat=True).distinct()
+            )
+            if len(proof_prices_currencies_list) == 1:
+                self.currency = self.prices.first().currency
+                self.save()
+            else:
+                print(
+                    "different currencies",
+                    self,
+                    self.prices.count(),
+                    proof_prices_currencies_list,
+                )

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -89,63 +89,97 @@ class ProofPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.location = LocationFactory(**LOCATION_NODE_652825274)
-        cls.proof = ProofFactory(
+        cls.proof_price_tag = ProofFactory(
             type=proof_constants.TYPE_PRICE_TAG,
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,
         )
         PriceFactory(
-            proof_id=cls.proof.id,
+            proof_id=cls.proof_price_tag.id,
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,
             price=1.0,
         )
         PriceFactory(
-            proof_id=cls.proof.id,
+            proof_id=cls.proof_price_tag.id,
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,
             price=2.0,
         )
+        cls.proof_receipt = ProofFactory(type=proof_constants.TYPE_RECEIPT)
+        PriceFactory(
+            proof_id=cls.proof_receipt.id,
+            location_osm_id=cls.location.osm_id,
+            location_osm_type=cls.location.osm_type,
+            price=2.0,
+            currency="EUR",
+            date="2024-06-30",
+        )
 
     def test_is_type_single_shop(self):
-        self.assertTrue(self.proof.is_type_single_shop)
+        self.assertTrue(self.proof_price_tag.is_type_single_shop)
 
     def test_update_price_count(self):
-        self.proof.refresh_from_db()
-        self.assertEqual(self.proof.price_count, 2)  # price post_save
+        self.proof_price_tag.refresh_from_db()
+        self.assertEqual(self.proof_price_tag.price_count, 2)  # price post_save
         # bulk delete prices to skip signals
-        self.proof.prices.all().delete()
-        self.assertEqual(self.proof.price_count, 2)  # should be 0
+        self.proof_price_tag.prices.all().delete()
+        self.assertEqual(self.proof_price_tag.price_count, 2)  # should be 0
         # update_price_count() should fix price_count
-        self.proof.update_price_count()
-        self.assertEqual(self.proof.price_count, 0)  # all deleted
+        self.proof_price_tag.update_price_count()
+        self.assertEqual(self.proof_price_tag.price_count, 0)  # all deleted
 
     def test_update_location(self):
         # existing
-        self.proof.refresh_from_db()
+        self.proof_price_tag.refresh_from_db()
         self.location.refresh_from_db()
-        self.assertEqual(self.proof.price_count, 2)
-        self.assertEqual(self.proof.location.id, self.location.id)
-        self.assertEqual(self.location.price_count, 2)
+        self.assertEqual(self.proof_price_tag.price_count, 2)
+        self.assertEqual(self.proof_price_tag.location.id, self.location.id)
+        self.assertEqual(self.location.price_count, 2 + 1)
         # update location
-        self.proof.update_location(
+        self.proof_price_tag.update_location(
             location_osm_id=6509705997,
             location_osm_type=location_constants.OSM_TYPE_NODE,
         )
         # check changes
-        self.proof.refresh_from_db()
+        self.proof_price_tag.refresh_from_db()
         self.location.refresh_from_db()
-        new_location = self.proof.location
+        new_location = self.proof_price_tag.location
         self.assertNotEqual(self.location, new_location)
-        self.assertEqual(self.proof.price_count, 2)
+        self.assertEqual(self.proof_price_tag.price_count, 2)
         self.assertEqual(new_location.price_count, 2)
-        self.assertEqual(self.location.price_count, 0)
+        self.assertEqual(self.location.price_count, 3 - 2)
         # update again, same location
-        self.proof.update_location(
+        self.proof_price_tag.update_location(
             location_osm_id=6509705997,
             location_osm_type=location_constants.OSM_TYPE_NODE,
         )
-        self.proof.refresh_from_db()
+        self.proof_price_tag.refresh_from_db()
         self.location.refresh_from_db()
-        self.assertEqual(self.proof.price_count, 2)
-        self.assertEqual(self.proof.location.price_count, 2)
+        self.assertEqual(self.proof_price_tag.price_count, 2)
+        self.assertEqual(self.proof_price_tag.location.price_count, 2)
+
+    def test_set_missing_location_from_prices(self):
+        self.proof_receipt.refresh_from_db()
+        self.assertTrue(self.proof_receipt.location is None)
+        self.assertEqual(self.proof_receipt.price_count, 1)
+        self.proof_receipt.set_missing_location_from_prices()
+        self.assertEqual(self.proof_receipt.location, self.location)
+
+    def test_set_missing_date_from_prices(self):
+        self.proof_receipt.refresh_from_db()
+        self.assertTrue(self.proof_receipt.date is None)
+        self.assertEqual(self.proof_receipt.price_count, 1)
+        self.proof_receipt.set_missing_date_from_prices()
+        self.assertEqual(
+            self.proof_receipt.date, self.proof_receipt.prices.first().date
+        )
+
+    def test_set_missing_currency_from_prices(self):
+        self.proof_receipt.refresh_from_db()
+        self.assertTrue(self.proof_receipt.currency is None)
+        self.assertEqual(self.proof_receipt.price_count, 1)
+        self.proof_receipt.set_missing_currency_from_prices()
+        self.assertEqual(
+            self.proof_receipt.currency, self.proof_receipt.prices.first().currency
+        )


### PR DESCRIPTION
### What

See discussion in https://github.com/openfoodfacts/open-prices-frontend/issues/879

New Proof methods to "fix" their missing location/date/currency (if added from old versions of the mobile app)

Added a CRON that runs every night