### PR TITLE
fix(Proofs): Deny users to delete a proof with prices

### DIFF
--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -50,6 +50,15 @@ class ProofViewSet(
             return ProofUpdateSerializer
         return self.serializer_class
 
+    def destroy(self, request: Request, *args, **kwargs) -> Response:
+        proof = self.get_object()
+        if proof.prices.count():
+            return Response(
+                {"detail": "Cannot delete proof with associated prices"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return super().destroy(request, *args, **kwargs)
+
     @extend_schema(request=ProofUploadSerializer, responses=ProofFullSerializer)
     @action(
         detail=False,

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -238,6 +238,8 @@ def proof_post_delete_remove_images(sender, instance, **kwargs):
     import os
 
     if instance.file_path_full:
-        os.remove(instance.file_path_full)
+        if os.path.exists(instance.file_path_full):
+            os.remove(instance.file_path_full)
     if instance.image_thumb_path_full:
-        os.remove(instance.image_thumb_path_full)
+        if os.path.exists(instance.image_thumb_path_full):
+            os.remove(instance.image_thumb_path_full)

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -97,14 +97,14 @@ class ProofPropertyTest(TestCase):
         )
         PriceFactory(
             proof_id=cls.proof_price_tag.id,
-            location_osm_id=cls.location.osm_id,
-            location_osm_type=cls.location.osm_type,
+            location_osm_id=cls.proof_price_tag.location.osm_id,
+            location_osm_type=cls.proof_price_tag.location.osm_type,
             price=1.0,
         )
         PriceFactory(
             proof_id=cls.proof_price_tag.id,
-            location_osm_id=cls.location.osm_id,
-            location_osm_type=cls.location.osm_type,
+            location_osm_id=cls.proof_price_tag.location.osm_id,
+            location_osm_type=cls.proof_price_tag.location.osm_type,
             price=2.0,
         )
         cls.proof_receipt = ProofFactory(type=proof_constants.TYPE_RECEIPT)


### PR DESCRIPTION
### What

Currently the API allows users to delete proofs even if the proof has prices.
(it would not delete prices, but set their proof_id to None)

To enforce data quality, and avoid mistakes, we restrict the deletion to only proofs without any prices.

What if the user linked the prices to a wrong proof for instance ? Will need to upload a new proof first, and the prices again to this new proof (maybe allow one day to update the price's proof, or update the proof image ?)

### Linked PRs

- https://github.com/openfoodfacts/open-prices/pull/197