### PR TITLE
feat(Proofs): Allow adding new proofs with a location_id

### DIFF
--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -7,7 +7,7 @@ from open_prices.locations.factories import LocationFactory
 LOCATION_OSM_NODE_652825274 = {
     "type": location_constants.TYPE_OSM,
     "osm_id": 652825274,
-    "osm_type": "NODE",
+    "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Monoprix",
     "osm_lat": "45.1805534",
     "osm_lon": "5.7153387",
@@ -16,7 +16,7 @@ LOCATION_OSM_NODE_652825274 = {
 LOCATION_OSM_NODE_6509705997 = {
     "type": location_constants.TYPE_OSM,
     "osm_id": 6509705997,
-    "osm_type": "NODE",
+    "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Carrefour",
     "price_count": 0,
 }

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -34,7 +34,7 @@ PRICE_APPLES = {
 LOCATION_OSM_NODE_652825274 = {
     "type": location_constants.TYPE_OSM,
     "osm_id": 652825274,
-    "osm_type": "NODE",
+    "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Monoprix",
     "osm_lat": "45.1805534",
     "osm_lon": "5.7153387",

--- a/open_prices/api/proofs/serializers.py
+++ b/open_prices/api/proofs/serializers.py
@@ -26,6 +26,9 @@ class ProofFullSerializer(ProofSerializer):
 
 class ProofUploadSerializer(serializers.ModelSerializer):
     file = serializers.FileField(required=True, use_url=False)
+    location_id = serializers.PrimaryKeyRelatedField(
+        queryset=Location.objects.all(), source="location", required=False
+    )
 
     class Meta:
         model = Proof
@@ -33,6 +36,10 @@ class ProofUploadSerializer(serializers.ModelSerializer):
 
 
 class ProofCreateSerializer(serializers.ModelSerializer):
+    location_id = serializers.PrimaryKeyRelatedField(
+        queryset=Location.objects.all(), source="location", required=False
+    )
+
     class Meta:
         model = Proof
         fields = Proof.FILE_FIELDS + Proof.CREATE_FIELDS

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -78,7 +78,11 @@ class ProofViewSet(
             "file_path": file_path,
             "mimetype": mimetype,
             "image_thumb_path": image_thumb_path,
-            **{key: request.data.get(key) for key in Proof.CREATE_FIELDS},
+            **{
+                key: request.data.get(key)
+                for key in Proof.CREATE_FIELDS
+                if key in request.data
+            },
         }
         # validate
         serializer = ProofCreateSerializer(data=proof_create_data)

--- a/open_prices/locations/tests.py
+++ b/open_prices/locations/tests.py
@@ -14,7 +14,7 @@ from open_prices.users.factories import UserFactory
 LOCATION_OSM_NODE_652825274 = {
     "type": location_constants.TYPE_OSM,
     "osm_id": 652825274,
-    "osm_type": "NODE",
+    "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Monoprix",
 }
 LOCATION_ONLINE_DECATHLON = {

--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -344,13 +344,13 @@ class Price(models.Model):
                         validation_errors = utils.add_validation_error(
                             validation_errors,
                             "location_osm_id",
-                            "Should not be set if `location_id` is filled",
+                            "Can only be set if location type is OSM",
                         )
                     if self.location_osm_type:
                         validation_errors = utils.add_validation_error(
                             validation_errors,
                             "location_osm_type",
-                            "Should not be set if `location_id` is filled",
+                            "Can only be set if location type is OSM",
                         )
                 elif location.type == location_constants.TYPE_OSM:
                     for LOCATION_FIELD in Price.DUPLICATE_LOCATION_FIELDS:

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -274,7 +274,7 @@ class PriceModelSaveTest(TestCase):
                 location_osm_id=652825274,
                 location_osm_type=LOCATION_OSM_TYPE_NOT_OK,
             )
-        # location unknown
+        # location_id unknown
         self.assertRaises(
             ValidationError,
             PriceFactory,

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -47,7 +47,11 @@ class Proof(models.Model):
         "receipt_price_count",
         "receipt_price_total",
     ]
-    CREATE_FIELDS = UPDATE_FIELDS + ["location_osm_id", "location_osm_type"]
+    CREATE_FIELDS = UPDATE_FIELDS + [
+        "location_osm_id",
+        "location_osm_type",
+        "location_id",  # extra field (optional)
+    ]
     FIX_PRICE_FIELDS = ["location", "date", "currency"]
     DUPLICATE_LOCATION_FIELDS = [
         "location_osm_id",
@@ -162,12 +166,12 @@ class Proof(models.Model):
                             self.location, LOCATION_FIELD.replace("location_", "")
                         )
                         if location_field_value:
-                            price_field_value = getattr(self, LOCATION_FIELD)
-                            if str(location_field_value) != str(price_field_value):
+                            proof_field_value = getattr(self, LOCATION_FIELD)
+                            if str(location_field_value) != str(proof_field_value):
                                 validation_errors = utils.add_validation_error(
                                     validation_errors,
                                     "location",
-                                    f"Location {LOCATION_FIELD} ({location_field_value}) does not match the price {LOCATION_FIELD} ({price_field_value})",
+                                    f"Location {LOCATION_FIELD} ({location_field_value}) does not match the proof {LOCATION_FIELD} ({proof_field_value})",
                                 )
         else:
             if self.location_osm_id:

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -13,12 +13,12 @@ from open_prices.proofs.models import Proof
 LOCATION_OSM_NODE_652825274 = {
     "type": location_constants.TYPE_OSM,
     "osm_id": 652825274,
-    "osm_type": "NODE",
+    "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Monoprix",
 }
 # LOCATION_OSM_NODE_6509705997 = {
 #     "osm_id": 6509705997,
-#     "osm_type": "NODE",
+#     "osm_type": location_constants.OSM_TYPE_NODE,
 #     "osm_name": "Carrefour",
 # }
 

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -35,6 +35,8 @@ class ProofModelSaveTest(TestCase):
             self.assertRaises(ValidationError, ProofFactory, date=DATE_NOT_OK)
 
     def test_proof_location_validation(self):
+        location_osm = LocationFactory()
+        location_online = LocationFactory(type=location_constants.TYPE_ONLINE)
         # both location_osm_id & location_osm_type not set
         ProofFactory(location_osm_id=None, location_osm_type=None)
         # location_osm_id
@@ -62,6 +64,37 @@ class ProofModelSaveTest(TestCase):
                 location_osm_id=652825274,
                 location_osm_type=LOCATION_OSM_TYPE_NOT_OK,
             )
+        # location_id unknown
+        self.assertRaises(
+            ValidationError,
+            ProofFactory,
+            location_id=999,
+            location_osm_id=None,
+            location_osm_type=None,
+        )
+        # cannot mix location_id & location_osm_id/type
+        self.assertRaises(
+            ValidationError,
+            ProofFactory,
+            location_id=location_osm.id,
+            location_osm_id=None,  # needed
+            location_osm_type=None,  # needed
+        )
+        self.assertRaises(
+            ValidationError,
+            ProofFactory,
+            location_id=location_online.id,
+            location_osm_id=LOCATION_OSM_ID_OK,  # should be None
+        )
+        # location_id ok
+        ProofFactory(
+            location_id=location_osm.id,
+            location_osm_id=location_osm.osm_id,
+            location_osm_type=location_osm.osm_type,
+        )
+        ProofFactory(
+            location_id=location_online.id, location_osm_id=None, location_osm_type=None
+        )
 
     def test_proof_receipt_fields(self):
         # receipt_price_count
@@ -230,3 +263,16 @@ class ProofPropertyTest(TestCase):
         self.assertEqual(
             self.proof_receipt.currency, self.proof_receipt.prices.first().currency
         )
+
+
+class ProofModelUpdateTest(TestCase):
+    def test_proof_update(self):
+        location = LocationFactory(**LOCATION_OSM_NODE_652825274)
+        proof_price_tag = ProofFactory(
+            type=proof_constants.TYPE_PRICE_TAG,
+            location_osm_id=location.osm_id,
+            location_osm_type=location.osm_type,
+            currency="EUR",
+        )
+        proof_price_tag.currency = "USD"
+        proof_price_tag.save()


### PR DESCRIPTION
### What

Similar to #527


Update the `Proof` model validation & API to allow users to pass a `location_id`
- if a OSM location, then the location_osm_id & location_osm_type are still mandatory and should match
- if a ONLINE location, then the location_osm_id & location_osm_type should be empty