### PR TITLE
refactor(API): store app_version in Price & Proof source field

### DIFF
--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -456,17 +456,23 @@ class PriceCreateApiTest(TestCase):
         self.assertEqual(response.status_code, 201)
 
     def test_price_create_with_app_name(self):
-        for app_name in ["", "test app"]:
-            response = self.client.post(
-                self.url + f"?app_name={app_name}",
-                self.data,
-                headers={"Authorization": f"Bearer {self.user_session.token}"},
-                content_type="application/json",
-            )
-            self.assertEqual(response.status_code, 201)
-            self.assertTrue("source" not in response.data)
-            p = Price.objects.last()
-            self.assertEqual(p.source, app_name)
+        for params, result in [
+            ("?", "API"),
+            ("?app_name=", ""),
+            ("?app_name=test app&app_version=", "test app"),
+            ("?app_name=mobile&app_version=1.0", "mobile (1.0)"),
+        ]:
+            with self.subTest(INPUT_OUPUT=(params, result)):
+                response = self.client.post(
+                    self.url + params,
+                    self.data,
+                    headers={"Authorization": f"Bearer {self.user_session.token}"},
+                    content_type="application/json",
+                )
+                self.assertEqual(response.status_code, 201)
+                self.assertTrue("source" not in response.data)
+                p = Price.objects.last()
+                self.assertEqual(p.source, result)
 
 
 class PriceUpdateApiTest(TestCase):

--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -13,6 +13,7 @@ from open_prices.api.prices.serializers import (
     PriceStatsSerializer,
     PriceUpdateSerializer,
 )
+from open_prices.api.utils import get_source_from_request
 from open_prices.common.authentication import CustomAuthentication
 from open_prices.prices.models import Price
 
@@ -59,7 +60,7 @@ class PriceViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         # get source
-        self.source = self.request.GET.get("app_name", "API")
+        self.source = get_source_from_request(self.request)
         # save
         price = self.perform_create(serializer)
         # return full price

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -240,17 +240,23 @@ class ProofCreateApiTest(TestCase):
         self.assertEqual(response.status_code, 201)
 
     def test_proof_create_with_app_name(self):
-        for app_name in ["", "test app"]:
-            # with empty app_name
-            response = self.client.post(
-                self.url + f"?app_name={app_name}",
-                self.data,
-                headers={"Authorization": f"Bearer {self.user_session.token}"},
-            )
-            self.assertEqual(response.status_code, 201)
-            self.assertTrue("source" not in response.data)
-            p = Proof.objects.last()
-            self.assertEqual(p.source, app_name)
+        for params, result in [
+            ("?", "API"),
+            ("?app_name=", ""),
+            ("?app_name=test app&app_version=", "test app"),
+            ("?app_name=mobile&app_version=1.0", "mobile (1.0)"),
+        ]:
+            with self.subTest(INPUT_OUPUT=(params, result)):
+                # with empty app_name
+                response = self.client.post(
+                    self.url + params,
+                    self.data,
+                    headers={"Authorization": f"Bearer {self.user_session.token}"},
+                )
+                self.assertEqual(response.status_code, 201)
+                self.assertTrue("source" not in response.data)
+                p = Proof.objects.last()
+                self.assertEqual(p.source, result)
 
 
 class ProofUpdateApiTest(TestCase):

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -14,6 +14,7 @@ from open_prices.api.proofs.serializers import (
     ProofUpdateSerializer,
     ProofUploadSerializer,
 )
+from open_prices.api.utils import get_source_from_request
 from open_prices.common.authentication import CustomAuthentication
 from open_prices.proofs.models import Proof
 from open_prices.proofs.utils import store_file
@@ -88,7 +89,7 @@ class ProofViewSet(
         serializer = ProofCreateSerializer(data=proof_create_data)
         serializer.is_valid(raise_exception=True)
         # get source
-        self.source = self.request.GET.get("app_name", "API")
+        self.source = get_source_from_request(self.request)
         # save
         proof = serializer.save(
             owner=self.request.user.user_id,

--- a/open_prices/api/utils.py
+++ b/open_prices/api/utils.py
@@ -6,3 +6,11 @@ def get_object_or_drf_404(model, **kwargs):
         return model.objects.get(**kwargs)
     except model.DoesNotExist:
         raise Http404(f"No {model._meta.verbose_name} matches the given query.")
+
+
+def get_source_from_request(request):
+    app_name = request.GET.get("app_name", "API")
+    app_version = request.GET.get("app_version", "")
+    if app_version:
+        return f"{app_name} ({app_version})"
+    return app_name


### PR DESCRIPTION
### What

We already store the app_name.
The mobile also sends us the app_version. Useful to understand which version the users are currently using.
