### PR TITLE
feat(API): Allow updating Proof location fields

### DIFF
--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -41,8 +41,8 @@ class ProofQuerySet(models.QuerySet):
 class Proof(models.Model):
     FILE_FIELDS = ["file_path", "mimetype", "image_thumb_path"]
     UPDATE_FIELDS = [
-        # "location_osm_id",
-        # "location_osm_type",
+        "location_osm_id",
+        "location_osm_type",
         "type",
         "currency",
         "date",
@@ -50,8 +50,6 @@ class Proof(models.Model):
         "receipt_price_total",
     ]
     CREATE_FIELDS = UPDATE_FIELDS + [
-        "location_osm_id",
-        "location_osm_type",
         "location_id",  # extra field (optional)
     ]
     FIX_PRICE_FIELDS = ["location", "date", "currency"]

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -17,6 +17,7 @@ LOCATION_OSM_NODE_652825274 = {
     "osm_name": "Monoprix",
 }
 LOCATION_OSM_NODE_6509705997 = {
+    "type": location_constants.TYPE_OSM,
     "osm_id": 6509705997,
     "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Carrefour",


### PR DESCRIPTION
### What

Following #538, allow updating Proof `location_osm_id` & `location_osm_type` fields
