### PR TITLE
chore: add CORS headers to images

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -74,11 +74,17 @@ http {
         location /img {
             alias /var/img;
 
-            location ~* \.(jpg|jpeg|png|webp|ttf|svg|ico)$ {
+            location ~* \.(jpg|jpeg|png|webp|ttf|svg|ico|webp)$ {
                 add_header Cache-Control public;
                 add_header Pragma public;
                 add_header Vary Accept-Encoding;
                 expires max;
+
+                # Add CORS headers
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+                add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
             }
         }
 


### PR DESCRIPTION
Otherwise, it can't be loaded from other website, ex: Label Studio instance

It was already tested (and hotfixed) in production.
