### PR TITLE
refactor(proofs): run OCR in post_save signal instead of create

### DIFF
--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -1,6 +1,4 @@
-from django.conf import settings
 from django_filters.rest_framework import DjangoFilterBackend
-from django_q.tasks import async_task
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters, mixins, status, viewsets
 from rest_framework.decorators import action
@@ -77,10 +75,6 @@ class ProofViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         file_path, mimetype, image_thumb_path = store_file(request.data.get("file"))
-        async_task(
-            "open_prices.proofs.utils.run_ocr_task",
-            f"{settings.IMAGES_DIR}/{file_path}",
-        )
         proof_create_data = {
             "file_path": file_path,
             "mimetype": mimetype,

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -14,7 +14,7 @@ from open_prices.prices.factories import PriceFactory
 from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.factories import ProofFactory
 from open_prices.proofs.models import Proof
-from open_prices.proofs.utils import run_ocr_task
+from open_prices.proofs.utils import fetch_and_save_ocr_data
 
 LOCATION_OSM_NODE_652825274 = {
     "type": location_constants.TYPE_OSM,
@@ -311,7 +311,7 @@ class ProofModelUpdateTest(TestCase):
 
 
 class RunOCRTaskTest(TestCase):
-    def test_run_ocr_task_success(self):
+    def test_fetch_and_save_ocr_data_success(self):
         response_data = {"responses": [{"textAnnotations": [{"description": "test"}]}]}
         with self.settings(GOOGLE_CLOUD_VISION_API_KEY="test_api_key"):
             # mock call to run_ocr_on_image
@@ -323,7 +323,7 @@ class RunOCRTaskTest(TestCase):
                     image_path = Path(f"{tmpdirname}/test.jpg")
                     with image_path.open("w") as f:
                         f.write("test")
-                    run_ocr_task(image_path)
+                    fetch_and_save_ocr_data(image_path)
                     mock_run_ocr_on_image.assert_called_once_with(
                         image_path, "test_api_key"
                     )

--- a/open_prices/proofs/utils.py
+++ b/open_prices/proofs/utils.py
@@ -169,7 +169,7 @@ def run_ocr_on_image(image_path: Path | str, api_key: str) -> dict[str, Any] | N
     return r.json()
 
 
-def run_ocr_task(image_path: Path | str, override: bool = False) -> None:
+def fetch_and_save_ocr_data(image_path: Path | str, override: bool = False) -> None:
     """Run OCR on the image stored at the given path and save the result to a
     JSON file.
 


### PR DESCRIPTION
### What

Following  #543

Some refactoring : 
- call the OCR async task in the model's post_save signal (instead of the API view)
- don't run the task when running the tests (locally or in the CI) : avoids calls to Google API
- rename run_ocr_task to fetch_and_save_ocr_data for clarification

--> similar to what we have currently with the Location & Product async tasks
