### PR TITLE
chore: update dependency openfoodfacts-python

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3386,4 +3386,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "7354400c6650b15a5be9a6a807d0fdca3217ff6dce34f708aa2c7c5acfaaa1f9"
+content-hash = "e4378c226cfd0a0ba4ff465ace8264ec1f11969fd4d0c8e8494c87184b8ba806"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1858,19 +1858,23 @@ files = [
 
 [[package]]
 name = "openfoodfacts"
-version = "0.2.1"
+version = "2.2.0"
 description = "Official Python SDK of Open Food Facts"
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "openfoodfacts-0.2.1-py3-none-any.whl", hash = "sha256:4bc0581f7e0a949078a6e5aba996f925f3f996e207927cf1c156fe36e3b16de8"},
-    {file = "openfoodfacts-0.2.1.tar.gz", hash = "sha256:dfe65884e00dad09a9d1168d227697d501b2c54ece24279446595dabaa9fc91e"},
+    {file = "openfoodfacts-2.2.0-py3-none-any.whl", hash = "sha256:172c953fd5727ffbe23bd2839afebc15cc346c3e186976e98b3d37026a90ba5b"},
+    {file = "openfoodfacts-2.2.0.tar.gz", hash = "sha256:e79ec1292238078de5e4857a19a7ccc66ca99b766311a9d7e60e9bf5315ac762"},
 ]
 
 [package.dependencies]
 pydantic = ">=2.0.0,<3.0.0"
 requests = ">=2.20.0"
 tqdm = ">=4.0.0,<5.0.0"
+
+[package.extras]
+pillow = ["Pillow (>=9.3,<10.4)"]
+redis = ["redis[hiredis] (>=5.1.0,<5.2.0)"]
 
 [[package]]
 name = "osmpythontools"
@@ -3382,4 +3386,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "0afde6a4649fc6ee2305387c9c46262803139ccf88b0c2734df756f41e0a3ab7"
+content-hash = "7354400c6650b15a5be9a6a807d0fdca3217ff6dce34f708aa2c7c5acfaaa1f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "~3.11"
 Babel = "~2.13.1"
-openfoodfacts = "2.2.0"
+openfoodfacts = "^2.2.0"
 psycopg2-binary = "~2.9.9"
 python-multipart = "~0.0.7"
 requests = "~2.31.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "~3.11"
 Babel = "~2.13.1"
-openfoodfacts = "0.2.1"
+openfoodfacts = "2.2.0"
 psycopg2-binary = "~2.9.9"
 python-multipart = "~0.0.7"
 requests = "~2.31.0"


### PR DESCRIPTION
### What

Lots of changes recently in the [openfoodfacts-python](https://github.com/openfoodfacts/openfoodfacts-python) package.

Update from v0.2.1 to v2.2.0
