### PR TITLE
feat(API): on Location POST, return existing if duplicate

### DIFF
--- a/open_prices/api/locations/serializers.py
+++ b/open_prices/api/locations/serializers.py
@@ -14,6 +14,10 @@ class LocationCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Location
         fields = Location.CREATE_FIELDS
+        # https://github.com/encode/django-rest-framework/issues/7173
+        # with UniqueConstraints, DRF wrongly validates.
+        # Leave it to the model's save()
+        validators = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -22,7 +26,4 @@ class LocationCreateSerializer(serializers.ModelSerializer):
             Location.TYPE_OSM_MANDATORY_FIELDS + Location.TYPE_ONLINE_MANDATORY_FIELDS
         ):
             self.fields[field].required = False
-
-    # with UniqueConstraints, DRF wrongly validates.
-    # Leave it to the model's save()
-    validators = []
+            self.fields[field].validators = []

--- a/open_prices/api/locations/views.py
+++ b/open_prices/api/locations/views.py
@@ -37,10 +37,16 @@ class LocationViewSet(
         serializer.is_valid(raise_exception=True)
         # get source
         source = get_source_from_request(self.request)
+        # before save: check if location already exists. If so, return it
+        try:
+            location = Location.objects.get(**serializer.validated_data)
+            return Response(
+                self.serializer_class(location).data, status=status.HTTP_200_OK
+            )
+        except Location.DoesNotExist:
+            pass
         # save
-        location = serializer.save(
-            source=source,
-        )
+        location = serializer.save(source=source)
         # return full location
         return Response(
             self.serializer_class(location).data, status=status.HTTP_201_CREATED

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -91,9 +91,6 @@ class ProofViewSet(
         # get source
         source = get_source_from_request(self.request)
         # save
-        proof = serializer.save(
-            owner=self.request.user.user_id,
-            source=source,
-        )
+        proof = serializer.save(owner=self.request.user.user_id, source=source)
         # return full proof
         return Response(ProofFullSerializer(proof).data, status=status.HTTP_201_CREATED)

--- a/open_prices/locations/tests.py
+++ b/open_prices/locations/tests.py
@@ -19,7 +19,7 @@ LOCATION_OSM_NODE_652825274 = {
 }
 LOCATION_ONLINE_DECATHLON = {
     "type": location_constants.TYPE_ONLINE,
-    "website_url": "https://www.decathlon.fr/",
+    "website_url": "https://www.decathlon.fr",
 }
 
 


### PR DESCRIPTION
### What

Following #446

Users can create a Location via the API.
But if the location already exist, we prefer to return the existing object (with a 200), instead of an error.
