### PR TITLE
feat: return proof predictions in `GET /api/v1/proof` route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ django-tests:
 	${DOCKER_COMPOSE_TEST} run --rm api poetry run python3 manage.py test
 
 
+django-tests-single: guard-args
+	@echo "🥫 Running specific tests …"
+	${DOCKER_COMPOSE_TEST} run --rm api poetry run python3 manage.py test -v 2 ${args}
+
 #------------#
 # Production #
 #------------#

--- a/open_prices/api/proofs/serializers.py
+++ b/open_prices/api/proofs/serializers.py
@@ -2,7 +2,21 @@ from rest_framework import serializers
 
 from open_prices.api.locations.serializers import LocationSerializer
 from open_prices.locations.models import Location
-from open_prices.proofs.models import Proof
+from open_prices.proofs.models import Proof, ProofPrediction
+
+
+class ProofPredictionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProofPrediction
+        fields = [
+            "type",
+            "model_name",
+            "model_version",
+            "created",
+            "data",
+            "value",
+            "max_confidence",
+        ]
 
 
 class ProofSerializer(serializers.ModelSerializer):
@@ -18,6 +32,7 @@ class ProofSerializer(serializers.ModelSerializer):
 
 class ProofFullSerializer(ProofSerializer):
     location = LocationSerializer()
+    predictions = ProofPredictionSerializer(many=True, read_only=True)
 
     class Meta:
         model = Proof

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -45,7 +45,13 @@ class ProofViewSet(
         if self.request.user.is_authenticated:
             queryset = Proof.objects.filter(owner=self.request.user.user_id)
             if self.request.method in ["GET"]:
-                return queryset.select_related("location")
+                # Select all proofs along with their locations using a select
+                # related query (1 single query)
+                # Then prefetch all the predictions related to the proof using
+                # a prefetch related query (only 1 query for all proofs)
+                return queryset.select_related("location").prefetch_related(
+                    "predictions"
+                )
             return queryset
         return self.queryset
 

--- a/open_prices/proofs/factories.py
+++ b/open_prices/proofs/factories.py
@@ -1,9 +1,11 @@
+import datetime
+
 import factory
 import factory.fuzzy
 from factory.django import DjangoModelFactory
 
 from open_prices.proofs import constants as proof_constants
-from open_prices.proofs.models import Proof
+from open_prices.proofs.models import Proof, ProofPrediction
 
 
 class ProofFactory(DjangoModelFactory):
@@ -16,3 +18,28 @@ class ProofFactory(DjangoModelFactory):
     # date = factory.Faker("date")
     # currency = factory.Faker("currency_symbol")
     # price_count = factory.LazyAttribute(lambda x: random.randrange(0, 100))
+
+
+class ProofPredictionFactory(DjangoModelFactory):
+    class Meta:
+        model = ProofPrediction
+
+    proof = factory.SubFactory(ProofFactory)
+    type = "CLASSIFICATION"
+    model_name = "price_proof_classification"
+    model_version = "price_proof_classification-1.0"
+    created = factory.LazyFunction(
+        lambda: datetime.datetime.now(tz=datetime.timezone.utc)
+    )
+    data = {
+        "prediction": [
+            {"label": "PRICE_TAG", "score": 0.98},
+            {"label": "SHELF", "score": 0.01},
+            {"label": "PRODUCT_WITH_PRICE", "score": 0.004},
+            {"label": "OTHER", "score": 0.002},
+            {"label": "WEB_PRINT", "score": 0.002},
+            {"label": "RECEIPT", "score": 0.002},
+        ]
+    }
+    value = "SHELF"
+    max_confidence = 0.98

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -355,11 +355,31 @@ class RunOCRTaskTest(TestCase):
 
 class ImageClassifierTest(TestCase):
     def test_run_and_save_proof_prediction_proof_does_not_exist(self):
-        self.assertIsNone(run_and_save_proof_prediction(1))
+        # check that we emit an error log
+        with self.assertLogs(
+            "open_prices.proofs.ml.image_classifier", level="ERROR"
+        ) as cm:
+            self.assertIsNone(run_and_save_proof_prediction(1))
+            self.assertEqual(
+                cm.output,
+                [
+                    "ERROR:open_prices.proofs.ml.image_classifier:Proof with id 1 not found"
+                ],
+            )
 
     def test_run_and_save_proof_prediction_proof_file_not_found(self):
         proof = ProofFactory()
-        self.assertIsNone(run_and_save_proof_prediction(proof.id))
+        # check that we emit an error log
+        with self.assertLogs(
+            "open_prices.proofs.ml.image_classifier", level="ERROR"
+        ) as cm:
+            self.assertIsNone(run_and_save_proof_prediction(proof.id))
+            self.assertEqual(
+                cm.output,
+                [
+                    f"ERROR:open_prices.proofs.ml.image_classifier:Proof file not found: {proof.file_path_full}"
+                ],
+            )
 
     def test_run_and_save_proof_prediction_proof(self):
         # Create a white blank image with Pillow


### PR DESCRIPTION
By doing so, the client can know all predictions related to the user proof.