### PR TITLE
refactor(API): only return proof.predictions in detail endpoint

### DIFF
--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -43,7 +43,7 @@ class PriceViewSet(
         elif self.request.method in ["PATCH", "DELETE"]:
             # only return prices owned by the current user
             if self.request.user.is_authenticated:
-                return Price.objects.filter(owner=self.request.user.user_id)
+                return self.queryset.filter(owner=self.request.user.user_id)
         return self.queryset
 
     def get_serializer_class(self):

--- a/open_prices/api/proofs/serializers.py
+++ b/open_prices/api/proofs/serializers.py
@@ -30,6 +30,14 @@ class ProofSerializer(serializers.ModelSerializer):
         exclude = ["location", "source"]
 
 
+class ProofHalfFullSerializer(ProofSerializer):
+    location = LocationSerializer()
+
+    class Meta:
+        model = Proof
+        exclude = ["source"]  # ProofSerializer.Meta.exclude
+
+
 class ProofFullSerializer(ProofSerializer):
     location = LocationSerializer()
     predictions = ProofPredictionSerializer(many=True, read_only=True)


### PR DESCRIPTION
### What

Following #601 
Only return proof predictions on the "retrieve" endpoint /api/v1/proofs/<proof_id> (not on the "list")