### PR TITLE
feat(API): Allow anonymous users to upload proofs

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -285,13 +285,22 @@ OFF_USER_AGENT = "open-prices/0.1.0"
 
 GOOGLE_CLOUD_VISION_API_KEY = os.getenv("GOOGLE_CLOUD_VISION_API_KEY")
 
+
 # Google Gemini API
 # ------------------------------------------------------------------------------
 
 GOOGLE_GEMINI_API_KEY = os.getenv("GOOGLE_GEMINI_API_KEY")
+
 
 # Triton Inference Server (ML)
 # ------------------------------------------------------------------------------
 
 TRITON_URI = os.getenv("TRITON_URI", "localhost:5504")
 ENABLE_ML_PREDICTIONS = os.getenv("ENABLE_ML_PREDICTIONS") == "True"
+
+
+# Open Food Facts
+# ------------------------------------------------------------------------------
+
+# https://world.openfoodfacts.org/contributor/openfoodfacts-contributors
+ANONYMOUS_USER_ID = "openfoodfacts-contributors"


### PR DESCRIPTION
### What

Changes to the proof `/upload` endpoint:
- remove the permission check
- set the owner to `openfoodfacts-contributors` if the user is not authenticated
