### PR TITLE
fix: create a product if needed after a redis update event

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -40,7 +40,9 @@ jobs:
         echo "CSRF_TRUSTED_ORIGINS=https://prices.openfoodfacts.net" >> $GITHUB_ENV
         # Triton server is on the same datacenter as the staging server, so we use the internal IP
         echo "TRITON_URI=10.1.0.200:5504" >> $GITHUB_ENV
-        echo "REDIS_HOST=redis.po_webnet" >> $GITHUB_ENV
+        # Open Prices fetches fetch data from Production Product Opener,
+        # so we use the production redis server
+        echo "REDIS_HOST=10.1.0.113" >> $GITHUB_ENV
         echo "REDIS_PORT=6379" >> $GITHUB_ENV
     - name: Set various variable for production deployment
       if: matrix.env == 'open-prices-org'

--- a/open_prices/products/tasks.py
+++ b/open_prices/products/tasks.py
@@ -16,10 +16,19 @@ def fetch_and_save_data_from_openfoodfacts(product: Product):
         product.save()
 
 
-def process_update(code: str, flavor: Flavor):
+def process_update(code: str, flavor: Flavor) -> None:
+    """Process an update of a product from Product Opener.
+
+    We update the product table with the latest information from Open Food
+    Facts. In case the product does not exist, we create it.
+
+    :param code: The code of the product
+    :param flavor: The flavor of the product
+    """
     product_openfoodfacts_details = common_openfoodfacts.get_product_dict(code, flavor)
 
     if product_openfoodfacts_details:
+        does_not_exist = False
         try:
             product = Product.objects.get(code=code)
         except Product.DoesNotExist:
@@ -27,10 +36,15 @@ def process_update(code: str, flavor: Flavor):
                 "Product %s does not exist in the database, cannot update product table",
                 code,
             )
-            return
+            does_not_exist = True
 
-        for key, value in product_openfoodfacts_details.items():
-            setattr(product, key, value)
+        if does_not_exist:
+            product_openfoodfacts_details["code"] = code
+            product = Product(**product_openfoodfacts_details)
+        else:
+            for key, value in product_openfoodfacts_details.items():
+                setattr(product, key, value)
+
         product.save()
 
 


### PR DESCRIPTION
We didn't create a product when the product was missing.

Also:
- add unit tests to `process_update`
- use production redis to listen to update: as Open Prices uses production OFF as backend, it makes sense to use the same.