### PR TITLE
chore: pass ENVIRONMENT envvar to services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ x-api-common: &api-common
   image: ghcr.io/openfoodfacts/open-prices/api:${TAG:-dev}
   restart: $RESTART_POLICY
   environment:
+    - ENVIRONMENT
     - POSTGRES_DB
     - POSTGRES_USER
     - POSTGRES_PASSWORD


### PR DESCRIPTION
The envvar was not passed to docker containers, resulting in sentry indicating "production" as environment irrespective of the real environment