### PR TITLE
feat(ProofMl): extract product_name and suggest ean-13 barcodes

### DIFF
--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -154,6 +154,7 @@ class Label(typing.TypedDict):
     unit: Unit
     organic: bool
     barcode: str
+    product_name: str
 
 
 class Labels(typing.TypedDict):
@@ -182,7 +183,7 @@ def extract_from_price_tags(images: Image.Image) -> Labels:
                 f"Here are {len(resized_images)} pictures containing a label. "
                 "For each picture of a label, please extract all the following attributes: "
                 "the product category matching product name, the origin category matching country of origin, the price, "
-                "is the product organic, the unit (per KILOGRAM or per UNIT) and the barcode. "
+                "is the product organic, the unit (per KILOGRAM or per UNIT) and the barcode (valid EAN-13 usually). "
                 f"I expect a list of {len(resized_images)} labels in your reply, no more, no less. "
                 "If you cannot decode an attribute, set it to an empty string"
             )


### PR DESCRIPTION
### What
- Ask gemini to also extract product_name
- Suggest that barcodes are EAN-13
- We could also add something like "Try to fix barcodes", but it doesn't seem to really help detection. Iinstead it tends to spit out wrong, but valid, barcodes. Which I believe would lead to more user mistakes during validation.

### Part of 
- https://github.com/openfoodfacts/open-prices-frontend/issues/1078
