### PR TITLE
refactor(API): store query params app_platform & app_page in source field

### DIFF
--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -202,6 +202,10 @@ class LocationCreateApiTest(TestCase):
                 ("?app_name=", ""),
                 ("?app_name=test app&app_version=", "test app"),
                 ("?app_name=mobile&app_version=1.0", "mobile (1.0)"),
+                (
+                    "?app_name=web&app_version=&app_page=/prices/add/multiple",
+                    "web - /prices/add/multiple",
+                ),
             ]
         ):
             with self.subTest(INPUT_OUPUT=(params, result)):

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -504,6 +504,10 @@ class PriceCreateApiTest(TestCase):
             ("?app_name=", ""),
             ("?app_name=test app&app_version=", "test app"),
             ("?app_name=mobile&app_version=1.0", "mobile (1.0)"),
+            (
+                "?app_name=web&app_version=&app_page=/prices/add/multiple",
+                "web - /prices/add/multiple",
+            ),
         ]:
             with self.subTest(INPUT_OUPUT=(params, result)):
                 response = self.client.post(

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -272,6 +272,10 @@ class ProofCreateApiTest(TestCase):
             ("?app_name=", ""),
             ("?app_name=test app&app_version=", "test app"),
             ("?app_name=mobile&app_version=1.0", "mobile (1.0)"),
+            (
+                "?app_name=web&app_version=&app_page=/prices/add/multiple",
+                "web - /prices/add/multiple",
+            ),
         ]:
             with self.subTest(INPUT_OUPUT=(params, result)):
                 # with empty app_name

--- a/open_prices/api/utils.py
+++ b/open_prices/api/utils.py
@@ -11,6 +11,12 @@ def get_object_or_drf_404(model, **kwargs):
 def get_source_from_request(request):
     app_name = request.GET.get("app_name", "API")
     app_version = request.GET.get("app_version", "")
+    app_platform = request.GET.get("app_platform", "")
+    app_page = request.GET.get("app_page", "")
     if app_version:
-        return f"{app_name} ({app_version})"
+        app_name += f" ({app_version})"
+    if app_platform:
+        app_name += f" ({app_platform})"
+    if app_page:
+        app_name += f" - {app_page}"
     return app_name


### PR DESCRIPTION
### What

Following #533 we store the `app_name` & `app_version` query params in the Price/Proof/Location source field.
In this PR we now also store the `app_platform` (sent from mobile) and a `app_page` (soon to be sent from the web app).

### Extra info

Will need to run a script to fix/adapt the past sources once the frontend sends the `app_page` info (instead of hacking the `app_version` param)