### PR TITLE
fix(Stats): fix User & Location stats after allowing any user to add prices on PRICE_TAG proofs

### DIFF
--- a/open_prices/locations/models.py
+++ b/open_prices/locations/models.py
@@ -198,10 +198,10 @@ class Location(models.Model):
         self.save(update_fields=["price_count"])
 
     def update_user_count(self):
-        from open_prices.prices.models import Price
+        from open_prices.proofs.models import Proof
 
         self.user_count = (
-            Price.objects.filter(location=self, owner__isnull=False)
+            Proof.objects.filter(location=self, owner__isnull=False)
             .values_list("owner", flat=True)
             .distinct()
             .count()

--- a/open_prices/locations/tests.py
+++ b/open_prices/locations/tests.py
@@ -8,6 +8,7 @@ from open_prices.locations.factories import LocationFactory
 from open_prices.locations.models import Location
 from open_prices.prices import constants as price_constants
 from open_prices.prices.factories import PriceFactory
+from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.factories import ProofFactory
 from open_prices.users.factories import UserFactory
 
@@ -158,7 +159,14 @@ class LocationPropertyTest(TestCase):
         cls.user = UserFactory()
         cls.user_2 = UserFactory()
         cls.location = LocationFactory(**LOCATION_OSM_NODE_652825274)
-        cls.proof = ProofFactory(
+        cls.proof_1 = ProofFactory(
+            type=proof_constants.TYPE_RECEIPT,
+            location_osm_id=cls.location.osm_id,
+            location_osm_type=cls.location.osm_type,
+            owner=cls.user.user_id,
+        )
+        cls.proof_2 = ProofFactory(
+            type=proof_constants.TYPE_PRICE_TAG,
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,
             owner=cls.user.user_id,
@@ -167,7 +175,7 @@ class LocationPropertyTest(TestCase):
             product_code="0123456789100",
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,
-            proof_id=cls.proof.id,
+            proof_id=cls.proof_1.id,
             price=1.0,
             owner=cls.user.user_id,
         )
@@ -175,6 +183,7 @@ class LocationPropertyTest(TestCase):
             product_code="0123456789101",
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,
+            proof_id=cls.proof_2.id,
             price=2.0,
             owner=cls.user_2.user_id,
         )
@@ -183,6 +192,7 @@ class LocationPropertyTest(TestCase):
             category_tag="en:tomatoes",
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,
+            proof_id=cls.proof_2.id,
             price=3,
             price_per=price_constants.PRICE_PER_KILOGRAM,
             owner=cls.user_2.user_id,
@@ -203,7 +213,7 @@ class LocationPropertyTest(TestCase):
         self.assertEqual(self.location.user_count, 0)
         # update_user_count() should fix user_count
         self.location.update_user_count()
-        self.assertEqual(self.location.user_count, 2)
+        self.assertEqual(self.location.user_count, 1)  # proof owners
 
     def test_update_product_count(self):
         self.location.refresh_from_db()
@@ -217,4 +227,4 @@ class LocationPropertyTest(TestCase):
         self.assertEqual(self.location.proof_count, 0)
         # update_proof_count() should fix location_count
         self.location.update_proof_count()
-        self.assertEqual(self.location.proof_count, 1)
+        self.assertEqual(self.location.proof_count, 2)

--- a/open_prices/products/tests.py
+++ b/open_prices/products/tests.py
@@ -6,6 +6,7 @@ from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from openfoodfacts import Flavor
 
+from open_prices.locations import constants as location_constants
 from open_prices.locations.factories import LocationFactory
 from open_prices.prices.factories import PriceFactory
 from open_prices.products import constants as product_constants
@@ -49,10 +50,14 @@ PRODUCT_OFF = {
     "unique_scans_n": 1051,
 }
 
-LOCATION_NODE_652825274 = {
+LOCATION_OSM_NODE_652825274 = {
+    "type": location_constants.TYPE_OSM,
     "osm_id": 652825274,
-    "osm_type": "NODE",
+    "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Monoprix",
+    "osm_lat": "45.1805534",
+    "osm_lon": "5.7153387",
+    "price_count": 15,
 }
 
 
@@ -107,7 +112,7 @@ class ProductPropertyTest(TestCase):
     def setUpTestData(cls):
         cls.product = ProductFactory(code="0123456789100", product_quantity=1000)
         cls.user = UserFactory()
-        cls.location = LocationFactory(**LOCATION_NODE_652825274)
+        cls.location = LocationFactory(**LOCATION_OSM_NODE_652825274)
         cls.proof = ProofFactory(
             location_osm_id=cls.location.osm_id,
             location_osm_type=cls.location.osm_type,

--- a/open_prices/stats/tests.py
+++ b/open_prices/stats/tests.py
@@ -1,6 +1,7 @@
 from django.db import IntegrityError
 from django.test import TestCase
 
+from open_prices.locations import constants as location_constants
 from open_prices.locations.factories import LocationFactory
 from open_prices.prices import constants as price_constants
 from open_prices.prices.factories import PriceFactory
@@ -9,10 +10,14 @@ from open_prices.proofs.factories import PriceTagFactory, ProofFactory
 from open_prices.stats.models import TotalStats
 from open_prices.users.factories import UserFactory
 
-LOCATION_NODE_652825274 = {
+LOCATION_OSM_NODE_652825274 = {
+    "type": location_constants.TYPE_OSM,
     "osm_id": 652825274,
-    "osm_type": "NODE",
+    "osm_type": location_constants.OSM_TYPE_NODE,
     "osm_name": "Monoprix",
+    "osm_lat": "45.1805534",
+    "osm_lon": "5.7153387",
+    "price_count": 15,
 }
 
 
@@ -32,7 +37,7 @@ class TotalStatsTest(TestCase):
         cls.total_stats = TotalStats.get_solo()
         cls.user = UserFactory()
         cls.user_2 = UserFactory()
-        cls.location = LocationFactory(**LOCATION_NODE_652825274)
+        cls.location = LocationFactory(**LOCATION_OSM_NODE_652825274)
         cls.location_2 = LocationFactory()
         cls.proof_price_tag = ProofFactory(
             type=proof_constants.TYPE_PRICE_TAG,

--- a/open_prices/users/models.py
+++ b/open_prices/users/models.py
@@ -65,14 +65,9 @@ class User(models.Model):
         self.save(update_fields=["product_count"])
 
     def update_proof_count(self):
-        from open_prices.prices.models import Price
+        from open_prices.proofs.models import Proof
 
-        self.proof_count = (
-            Price.objects.filter(owner=self.user_id, proof_id__isnull=False)
-            .values_list("proof_id", flat=True)
-            .distinct()
-            .count()
-        )
+        self.proof_count = Proof.objects.filter(owner=self.user_id).count()
         self.save(update_fields=["proof_count"])
 
 

--- a/open_prices/users/models.py
+++ b/open_prices/users/models.py
@@ -43,10 +43,10 @@ class User(models.Model):
         self.save(update_fields=["price_count"])
 
     def update_location_count(self):
-        from open_prices.prices.models import Price
+        from open_prices.proofs.models import Proof
 
         self.location_count = (
-            Price.objects.filter(owner=self.user_id, location_id__isnull=False)
+            Proof.objects.filter(owner=self.user_id, location_id__isnull=False)
             .values_list("location_id", flat=True)
             .distinct()
             .count()


### PR DESCRIPTION
### What

Following #609 
We need to adapt how some stats are calculated:
- User location count: do the aggregation on proofs, not on prices
- Location user count: do the aggregation on proofs, not on prices

Also simplified the User proof count calculation. And update the tests
