### PR TITLE
feat(Price Stats): Stats grouped by

### DIFF
--- a/open_prices/api/prices/filters.py
+++ b/open_prices/api/prices/filters.py
@@ -41,9 +41,6 @@ class PriceFilter(django_filters.FilterSet):
     created__lte = django_filters.DateTimeFilter(
         field_name="created", lookup_expr="lte"
     )
-    product__categories_tags__contains = django_filters.CharFilter(
-        field_name="product__categories_tags", lookup_expr="icontains"
-    )
 
     class Meta:
         model = Price

--- a/open_prices/api/prices/filters.py
+++ b/open_prices/api/prices/filters.py
@@ -41,6 +41,9 @@ class PriceFilter(django_filters.FilterSet):
     created__lte = django_filters.DateTimeFilter(
         field_name="created", lookup_expr="lte"
     )
+    product__categories_tags__contains = django_filters.CharFilter(
+        field_name="product__categories_tags", lookup_expr="icontains"
+    )
 
     class Meta:
         model = Price

--- a/open_prices/api/prices/filters.py
+++ b/open_prices/api/prices/filters.py
@@ -7,6 +7,12 @@ class PriceFilter(django_filters.FilterSet):
     product_id__isnull = django_filters.BooleanFilter(
         field_name="product_id", lookup_expr="isnull"
     )
+    product_labels_tags__contains = django_filters.CharFilter(
+        field_name="product__labels_tags", lookup_expr="icontains"
+    )
+    product_categories_tags__contains = django_filters.CharFilter(
+        field_name="product__categories_tags", lookup_expr="icontains"
+    )
     labels_tags__contains = django_filters.CharFilter(
         field_name="labels_tags", lookup_expr="icontains"
     )
@@ -52,4 +58,5 @@ class PriceFilter(django_filters.FilterSet):
             "date",
             "proof_id",
             "owner",
+            "proof__type",
         ]

--- a/open_prices/api/prices/serializers.py
+++ b/open_prices/api/prices/serializers.py
@@ -64,3 +64,23 @@ class PriceStatsSerializer(serializers.Serializer):
     price__min = serializers.DecimalField(max_digits=10, decimal_places=2)
     price__max = serializers.DecimalField(max_digits=10, decimal_places=2)
     price__avg = serializers.DecimalField(max_digits=10, decimal_places=2)
+    price__sum = serializers.DecimalField(max_digits=10, decimal_places=2)
+
+
+class GroupedPriceStatsQuerySerializer(serializers.Serializer):
+    group_by = serializers.CharField(
+        required=True, help_text="Field by which to group the statistics"
+    )
+
+
+class GroupedPriceStatsSerializer(PriceStatsSerializer):
+    # Override representation to dynamically include the group field
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        # Add the grouping field dynamically
+        for key in instance:
+            if key not in representation:  # It's likely the group field
+                representation[key] = instance[key]
+
+        return representation

--- a/open_prices/api/prices/serializers.py
+++ b/open_prices/api/prices/serializers.py
@@ -71,6 +71,9 @@ class GroupedPriceStatsQuerySerializer(serializers.Serializer):
     group_by = serializers.CharField(
         required=True, help_text="Field by which to group the statistics"
     )
+    order_by = serializers.CharField(
+        required=False, help_text="Field by which to order the results"
+    )
 
 
 class GroupedPriceStatsSerializer(PriceStatsSerializer):

--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -104,10 +104,11 @@ class PriceViewSet(
         # Validate and parse query parameters using the serializer
         serializer = GroupedPriceStatsQuerySerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
-        group_by = serializer.validated_data["group_by"]
+        group_by = serializer.validated_data.get("group_by")
+        order_by = serializer.validated_data.get("order_by", None)
 
         try:
-            data = qs.calculate_grouped_stats(group_by)
+            data = qs.calculate_grouped_stats(group_by, order_by)
         except FieldError:
             return Response(
                 {"detail": f"Invalid group_by field: {group_by}"},

--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -57,7 +57,7 @@ class PriceQuerySet(models.QuerySet):
             price__sum=Sum("price"),
         )
 
-    def calculate_grouped_stats(self, group_by):
+    def calculate_grouped_stats(self, group_by, order_by):
         group_by_list = group_by.split(",")
         if (
             "month" in group_by_list
@@ -69,6 +69,10 @@ class PriceQuerySet(models.QuerySet):
             )
         else:
             queryset = self
+        if order_by:
+            order_by_list = [order_by]
+        else:
+            order_by_list = group_by_list
         return (
             queryset.values(*group_by_list)
             .annotate(
@@ -81,7 +85,7 @@ class PriceQuerySet(models.QuerySet):
                 ),
                 price__sum=Sum("price"),
             )
-            .order_by(*group_by_list)
+            .order_by(*order_by_list)
         )
 
 


### PR DESCRIPTION
### What
Adds a new `GET /api/v1/prices/grouped_stats` endpoint, with mandatory param `group_by` matching an existing field.

For example,  `GET /api/v1/prices/grouped_stats?group_by=date&size=2` gives

```json
{
  "items": [
    {
      "date": "2018-03-27",
      "price__count": 24,
      "price__min": 0.47,
      "price__max": 7.8,
      "price__avg": 2.55,
      "price__sum": 61.2
    },
    {
      "date": "2018-03-31",
      "price__count": 13,
      "price__min": 0.54,
      "price__max": 6.49,
      "price__avg": 3.19,
      "price__sum": 41.49
    }
  ],
  "page": 1,
  "pages": 55,
  "size": 2,
  "total": 110
}
```

Specific time fields are also supported, even though they are not part of the model. Users can group by `month`, `week` and `year`.

Results should be properly paginated.


By default, results are ordered following the `group_by` parameter (here by date), using the `order_by` params helps sorting the items with one of the computed param.

For example,  `GET /api/v1/prices/grouped_stats?group_by=date&size=2&order_by=-price__count` gives

```json
{
  "items": [
    {
      "date": "2021-01-11",
      "price__count": 37,
      "price__min": 0.4,
      "price__max": 5.99,
      "price__avg": 2.05,
      "price__sum": 75.8
    },
    {
      "date": "2018-08-09",
      "price__count": 37,
      "price__min": 0.59,
      "price__max": 12.15,
      "price__avg": 2.67,
      "price__sum": 98.71
    }
  ],
  "page": 1,
  "pages": 55,
  "size": 2,
  "total": 110
}
```

### Fixes bug(s)
- Fixes #674 
- Also fixes #673, en though it could (should) have been a separate PR.

### Notes
- This is a pretty hacky implementation of a solution, I'm not really confident about it.
- For example, I had to use `OpenApiParameter` for it to show up in the docs, which is weird.
- I am also unsure about the performances of these groupings on a production database.