### PR TITLE
refactor(Price tags): Make ready_for_price_tag_validation field editable by user

### DIFF
--- a/open_prices/proofs/constants.py
+++ b/open_prices/proofs/constants.py
@@ -34,11 +34,6 @@ PRICE_TAG_PREDICTION_TYPE_CHOICES = [
     (PRICE_TAG_EXTRACTION_TYPE, PRICE_TAG_EXTRACTION_TYPE)
 ]
 
-PROOF_READY_FOR_PRICE_TAG_VALIDATION_SOURCE_LIST = [
-    "/proofs/add/single",
-    "/proofs/add/multiple",
-]
-
 
 class PriceTagStatus(enum.IntEnum):
     deleted = 0

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -122,6 +122,15 @@ class ProofModelSaveTest(TestCase):
             location_id=location_online.id, location_osm_id=None, location_osm_type=None
         )
 
+    def test_proof_price_tag_fields(self):
+        # ready_for_price_tag_validation
+        self.assertRaises(
+            ValidationError,
+            ProofFactory,
+            ready_for_price_tag_validation=True,
+            type=proof_constants.TYPE_PRICE_TAG,
+        )
+
     def test_proof_receipt_fields(self):
         # receipt_price_count
         for RECEIPT_PRICE_COUNT_NOT_OK in [-5]:  # Decimal("45.10")
@@ -165,13 +174,6 @@ class ProofModelSaveTest(TestCase):
             receipt_price_total=5,
             type=proof_constants.TYPE_PRICE_TAG,
         )
-
-    def test_proof_ready_for_price_tag_validation_field(self):
-        proof = ProofFactory(type=proof_constants.TYPE_PRICE_TAG, source="/proofs/add/")
-        self.assertFalse(proof.ready_for_price_tag_validation)
-        proof.source = "/proofs/add/multiple"
-        proof.save()
-        self.assertTrue(proof.ready_for_price_tag_validation)
 
 
 class ProofQuerySetTest(TestCase):


### PR DESCRIPTION
### What

Following #656

Change the behavior of the `Proof.ready_for_price_tag_validation` field
- user sets its value on create
- not dependent on the source anymore

### Why

To allow users to opt-out freely of the price tag validation workflow.
