### PR TITLE
feat(Proofs): ML: receipt content extraction

### DIFF
--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -703,6 +703,10 @@ def run_and_save_receipt_extraction_prediction(
     :return: the ProofPrediction instance created, or None if the prediction
         already exists and overwrite is False
     """
+    if proof.type != proof_constants.TYPE_RECEIPT:
+        logger.debug("Skipping proof %s, not of type RECEIPT", proof.id)
+        return None
+
     if ProofPrediction.objects.filter(
         proof=proof, model_name=GEMINI_MODEL_NAME
     ).exists():
@@ -740,9 +744,9 @@ def run_and_save_proof_prediction(
     Currently, the following models are run:
 
     - proof type classification model
-    - receipt extraction model
     - price tag detection model (object detector)
     - price tag extraction model
+    - receipt extraction model
 
     :param proof_id: the ID of the proof to be classified
     :param run_price_tag_extraction: whether to run the price tag extraction
@@ -760,8 +764,8 @@ def run_and_save_proof_prediction(
 
     image = Image.open(file_path_full)
     run_and_save_proof_type_prediction(image, proof)
-    if run_receipt_extraction and proof.type == proof_constants.TYPE_RECEIPT:
-        run_and_save_receipt_extraction_prediction(image, proof)
     run_and_save_price_tag_detection(
         image, proof, run_extraction=run_price_tag_extraction
     )
+    if run_receipt_extraction:
+        run_and_save_receipt_extraction_prediction(image, proof)

--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -731,7 +731,9 @@ def run_and_save_receipt_extraction_prediction(
 
 
 def run_and_save_proof_prediction(
-    proof: Proof, run_price_tag_extraction: bool = True
+    proof: Proof,
+    run_price_tag_extraction: bool = True,
+    run_receipt_extraction: bool = True,
 ) -> None:
     """Run all ML models on a specific proof, and save the predictions in DB.
 
@@ -758,7 +760,7 @@ def run_and_save_proof_prediction(
 
     image = Image.open(file_path_full)
     run_and_save_proof_type_prediction(image, proof)
-    if proof.type == proof_constants.TYPE_RECEIPT:
+    if run_receipt_extraction and proof.type == proof_constants.TYPE_RECEIPT:
         run_and_save_receipt_extraction_prediction(image, proof)
     run_and_save_price_tag_detection(
         image, proof, run_extraction=run_price_tag_extraction

--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -758,7 +758,8 @@ def run_and_save_proof_prediction(
 
     image = Image.open(file_path_full)
     run_and_save_proof_type_prediction(image, proof)
-    run_and_save_receipt_extraction_prediction(image, proof)
+    if proof.type == proof_constants.TYPE_RECEIPT:
+        run_and_save_receipt_extraction_prediction(image, proof)
     run_and_save_price_tag_detection(
         image, proof, run_extraction=run_price_tag_extraction
     )

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -430,7 +430,11 @@ class MLModelTest(TestCase):
                         return_value=None,
                     ) as mock_detect_price_tags,
                 ):
-                    run_and_save_proof_prediction(proof, run_price_tag_extraction=False)
+                    run_and_save_proof_prediction(
+                        proof,
+                        run_price_tag_extraction=False,
+                        run_receipt_extraction=False,
+                    )
                     mock_predict_proof_type.assert_called_once()
                     mock_detect_price_tags.assert_not_called()
 
@@ -513,7 +517,11 @@ class MLModelTest(TestCase):
                         return_value=detect_price_tags_response,
                     ) as mock_detect_price_tags,
                 ):
-                    run_and_save_proof_prediction(proof, run_price_tag_extraction=False)
+                    run_and_save_proof_prediction(
+                        proof,
+                        run_price_tag_extraction=False,
+                        run_receipt_extraction=False,
+                    )
                     mock_predict_proof_type.assert_called_once()
                     mock_detect_price_tags.assert_called_once()
 


### PR DESCRIPTION
### What
- Uses gemini to extract receipt content
- Stores it in the proof_predictions database

### Notes

I did try to ask Gemini for way more information (see commented fields), but it tends to confuse it. Sometimes it replies with all fields, and sometimes it forgets to add everything, including price.
```python
class Item(typing.TypedDict):
    product: Products
    price: float
    # origin: Origin
    # unit: Unit
    # organic: bool
    # barcode: str
    product_name: str
    # is_discount: bool
    # discount_price: float

class Receipt(typing.TypedDict):
    store_name: str
    store_address: str
    store_city_name: str
    date: str
    # number_of_articles: int
    # total_price: float
    items: list[Item]
```

The shorter list seems to perform better.

Extraction of store name, address and date could be quite useful. However, in the current process, these are already specified by the user when the proof reaches the ml (also true for proof type prediction).

Since users currently manually mark the proof as a receipt, we use this info to only run receipt extraction on such proofs. We could consider using the proof type prediction instead.

Finally, this whole process requires the `ENABLE_ML_PREDICTIONS` env to be True because it is called at the same time as other proof ml processes. Some tiny changes are required to run this locally if no Triton Inference Server is running. The Triton server isn't required for this process, but is mandatory for the other ones.

### Fixes bug(s)
- Fixes #681 


### Screenshot
Some examples of extraction:
<img src="https://github.com/user-attachments/assets/e8eef66b-504e-420c-a086-6fc23e4daa94" height="300">
(Note the confusion with the "PFAND", the money-back german system when you take or return glassware)
```json
{
    "date": "",
    "items": [
        {
            "price": 0.65,
            "product": "en:bananas",
            "product_name": "FRUCHTJ. VAN&BALL"
        },
        {
            "price": 1.29,
            "product": "en:cherries",
            "product_name": "KIRSCH GRUETZE"
        },
        {
            "price": 3.38,
            "product": "en:mandarin-oranges",
            "product_name": "JARRITOS MANDARI"
        },
        {
            "price": 0.5,
            "product": "other",
            "product_name": "PFAND 0,25 EURO"
        },
        {
            "price": 1.09,
            "product": "en:strawberries",
            "product_name": "STRAWB. KIWI"
        },
        {
            "price": 0.25,
            "product": "other",
            "product_name": "PFAND 0,25 EURO"
        }
    ],
    "store_address": "Reichenhainer Str. 55",
    "store_city_name": "Chemnitz",
    "store_name": "Nahkauf Oliver Kettler"
}
```
<img src="https://github.com/user-attachments/assets/eda1949d-c963-4fa8-9bed-e495a904125f" height="300">

```json
{
    "date": "mercredi 19 2 2025",
    "items": [
        {
            "price": 2.35,
            "product": "en:apples",
            "product_name": "AMANDINE 50CL"
        },
        {
            "price": 6.98,
            "product": "other",
            "product_name": "CREME DE MARRONS"
        },
        {
            "price": 1.71,
            "product": "en:kiwis",
            "product_name": "KIWI"
        },
        {
            "price": 2.98,
            "product": "other",
            "product_name": "CREME FRAICHE LAIT D"
        },
        {
            "price": 1.04,
            "product": "en:bananas",
            "product_name": "BANANE"
        },
        {
            "price": 3.11,
            "product": "other",
            "product_name": "VRAC PISTACHE C*PRE"
        },
        {
            "price": 4.18,
            "product": "other",
            "product_name": "CHOCO CREME COCO 70G"
        },
        {
            "price": 5.96,
            "product": "other",
            "product_name": "CHOCOLAT VANILLE"
        },
        {
            "price": 2.68,
            "product": "en:zucchini",
            "product_name": "COURGETTE"
        },
        {
            "price": 3.19,
            "product": "other",
            "product_name": "CREME BREBIS CAFE 2X"
        },
        {
            "price": 1.76,
            "product": "en:broccoli",
            "product_name": "CHOU BROCOLI"
        },
        {
            "price": 2.09,
            "product": "en:radishes",
            "product_name": "RADIS MULTICOLOR"
        },
        {
            "price": 4.74,
            "product": "en:endives",
            "product_name": "ENDIVE"
        },
        {
            "price": 2.95,
            "product": "other",
            "product_name": "CRAC' O CHOC RIZ SOU"
        },
        {
            "price": 4.98,
            "product": "other",
            "product_name": "GUIMAUVE RACINES"
        },
        {
            "price": 3.97,
            "product": "other",
            "product_name": "AUBEPINE SOMMITES"
        },
        {
            "price": 4.98,
            "product": "other",
            "product_name": "BADIANE"
        },
        {
            "price": 4.97,
            "product": "other",
            "product_name": "MAUVE FLEURS 10G"
        },
        {
            "price": 2.37,
            "product": "other",
            "product_name": "CHIPS NATURES SALEES"
        }
    ],
    "store_address": "8 place de l'abattoir",
    "store_city_name": "STRASBOURG",
    "store_name": "COTE NATURE STRASBOURG"
}
```
<img src="https://github.com/user-attachments/assets/35641853-c6b0-46ca-a842-8d17aee4a718" height="300">

```json
{
    "date": "18/09/24",
    "items": [
        {
            "price": 3.35,
            "product": "en:berries",
            "product_name": "YRT FRT ROUGE P.YOPLAIT 8X125G"
        },
        {
            "price": 3.14,
            "product": "en:mushrooms",
            "product_name": "COMTE AOP LC34% ENTREMONT 200G"
        },
        {
            "price": 2.13,
            "product": "en:berries",
            "product_name": "CR.FRAICHE ISIGNY AOP PV 20CL"
        },
        {
            "price": 9.74,
            "product": "other",
            "product_name": "HOVE TERRA DELYSSA BIO 0,75L"
        },
        {
            "price": 4.76,
            "product": "other",
            "product_name": "CHATAIGN.CUITES ENT.U BIO 210G"
        },
        {
            "price": 4.29,
            "product": "other",
            "product_name": "THON LISTAO NAT. PECHE UX2 280G"
        },
        {
            "price": 3.16,
            "product": "other",
            "product_name": "CHIPS PAYSANNE SOG BRET'S 250G"
        },
        {
            "price": 2.99,
            "product": "other",
            "product_name": "RATATOUILLE U BIO BOCAL 520G"
        },
        {
            "price": 2.33,
            "product": "other",
            "product_name": "SABLES NAPPES CHOC.LT UBIO200G"
        },
        {
            "price": 2.13,
            "product": "other",
            "product_name": "BISCOT.FROMENT GERM.U BIO 300G"
        },
        {
            "price": 1.25,
            "product": "other",
            "product_name": "MAIS DOUX U BIO 1/2 285G"
        },
        {
            "price": 1.99,
            "product": "en:cucumbers",
            "product_name": "CONCOMBRE"
        },
        {
            "price": 1.08,
            "product": "en:zucchini",
            "product_name": "COURGETTE"
        },
        {
            "price": 1.19,
            "product": "en:carrots",
            "product_name": "CAROTTE HAUTS-DE-FRANCE"
        }
    ],
    "store_address": "34 BLD ORNANO / 125 RUE DE CLIGNANCOURT PARIS 75018 FR",
    "store_city_name": "PARIS",
    "store_name": "SUPER U"
}
```

These json are stored in the proof prediction db and show up when fetching the proof via API
![Capture](https://github.com/user-attachments/assets/9d873bc7-c51d-4e1f-9ca7-2a6325e29bf1)
