### PR TITLE
docs(API): custom paginated response schema

### DIFF
--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -23,3 +23,35 @@ class CustomPagination(pagination.PageNumberPagination):
                 "total": self.page.paginator.count,
             }
         )
+
+    def get_paginated_response_schema(self, schema):
+        return {
+            "type": "object",
+            "required": ["items", "page", "pages", "size", "total"],
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": schema,
+                },
+                "page": {
+                    "type": "integer",
+                    "description": "Current page number",
+                    "example": 1,
+                },
+                "pages": {
+                    "type": "integer",
+                    "description": "Total number of pages",
+                    "example": 16,
+                },
+                "size": {
+                    "type": "integer",
+                    "description": "Number of items per page",
+                    "example": 100,
+                },
+                "total": {
+                    "type": "integer",
+                    "description": "Total number of items",
+                    "example": 1531,
+                },
+            },
+        }

--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -1,14 +1,14 @@
-from rest_framework import pagination
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 
-class CustomPagination(pagination.PageNumberPagination):
+class CustomPagination(PageNumberPagination):
     """
-    https://www.django-rest-framework.org/api-guide/pagination/#custom-pagination-styles
-    - results -> items
-    - count -> total
-    - next -> ?
-    - previous -> ?
+    docs: https://www.django-rest-framework.org/api-guide/pagination/#custom-pagination-styles  # noqa
+    why do we override the pagination keys? we used to have fastapi-pagination before  # noqa
+    - overriden keys: results -> items; count -> total
+    - added keys: page, pages, size
+    - removed keys: next, previous
     """
 
     page_size_query_param = "size"


### PR DESCRIPTION
### What
- Fix discrepancy between Api Docs and our custom paginitation keywords.

Example with user lists, but it applies to all paginated results (prices, proofs ..)


| Before | After |
| ------ | ------ |
|![paginationbefore](https://github.com/user-attachments/assets/80ef9346-2f1c-47e1-959c-3f1aba8075aa) | ![paginationfix](https://github.com/user-attachments/assets/ff45a983-ea85-40df-997c-38f1d1e7d082)|

### Fixes bug(s)
- Fixes #742
