### PR TITLE
refactor(API): set default size to 10. and limit max size to 100

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -188,7 +188,6 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "ORDERING_PARAM": "order_by",
     "DEFAULT_PAGINATION_CLASS": "open_prices.api.pagination.CustomPagination",
-    "PAGE_SIZE": 100,
     "COERCE_DECIMAL_TO_STRING": False,
 }
 

--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -11,7 +11,9 @@ class CustomPagination(PageNumberPagination):
     - removed keys: next, previous
     """
 
+    page_size = 10
     page_size_query_param = "size"
+    max_page_size = 100
 
     def get_paginated_response(self, data):
         return Response(

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -101,7 +101,16 @@ class PriceListPaginationApiTest(TestCase):
         self.assertEqual(len(response.data["items"]), 3)
         self.assertEqual(response.data["page"], 1)
         self.assertEqual(response.data["pages"], 1)
-        self.assertEqual(response.data["size"], 100)
+        self.assertEqual(response.data["size"], 10)  # default
+        self.assertEqual(response.data["items"][0]["price"], 15.00)  # default order
+        # size=150
+        url = self.url + "?size=150"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(len(response.data["items"]), 3)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 1)
+        self.assertEqual(response.data["size"], 100)  # max to 100
         self.assertEqual(response.data["items"][0]["price"], 15.00)  # default order
         # size=1
         url = self.url + "?size=1"


### PR DESCRIPTION
### What

Our API was wrongly configured, we didn't have a max size set. 
I was seeing calls with `?size=700000` (:eyes:) making the server crash...
- default to size = 10
- max size = 100