### PR TITLE
refactor(Proofs): API: allow multiple filters on `type`

### DIFF
--- a/open_prices/api/proofs/filters.py
+++ b/open_prices/api/proofs/filters.py
@@ -1,9 +1,14 @@
 import django_filters
 
+from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.models import PriceTag, Proof
 
 
 class ProofFilter(django_filters.FilterSet):
+    type = django_filters.MultipleChoiceFilter(
+        field_name="type",
+        choices=proof_constants.TYPE_CHOICES,
+    )
     location_id__isnull = django_filters.BooleanFilter(
         field_name="location_id", lookup_expr="isnull"
     )
@@ -35,7 +40,6 @@ class ProofFilter(django_filters.FilterSet):
     class Meta:
         model = Proof
         fields = [
-            "type",
             "location_osm_id",
             "location_osm_type",
             "location_id",

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -131,6 +131,12 @@ class ProofListFilterApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 1)
         self.assertEqual(response.data["items"][0]["price_count"], 15)
+        url = self.url + "?type=PRICE_TAG"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 2)
+        url = self.url + "?type=RECEIPT&type=PRICE_TAG"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1 + 2)
 
     def test_proof_list_filter_by_owner(self):
         url = self.url + f"?owner={self.user_session.user.user_id}"


### PR DESCRIPTION
### What

Similar to #741

Allow filtering by multiple values of the `type` field