### PR TITLE
refactor(Auth): Drop invalid json parser from post api

### DIFF
--- a/open_prices/api/auth/views.py
+++ b/open_prices/api/auth/views.py
@@ -3,6 +3,7 @@ import time
 from django.conf import settings
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -24,6 +25,7 @@ from open_prices.users.utils import get_or_create_session
 
 class LoginView(APIView):
     serializer_class = LoginSerializer
+    parser_classes = [FormParser, MultiPartParser]
 
     @extend_schema(responses=SessionResponseSerializer, tags=["auth"])
     def post(self, request: Request) -> Response:


### PR DESCRIPTION
### What
- OpenAPI docs were showing json as a possible content-type option for `POST /api/v1/auth`, which was incorrect

### Fixes bug(s)
- Fixes #544

### Note
- Did a quick check to make sure this doesn't affect the dart app https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/lib/src/open_prices_api_client.dart
  - It shouldn't be an issue, the app is correctly using `Content-Type: application/x-www-form-urlencoded` by default
