### PR TITLE
refactor(Proofs): take owner_consumption into account to differentiate community & consumption

### DIFF
--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -53,13 +53,12 @@ class PriceQuerySet(models.QuerySet):
 
     def has_type_group_community(self):
         # TODO: what about prices without proofs?
-        return self.prefetch_related("proof").filter(
-            proof__type__in=proof_constants.TYPE_GROUP_COMMUNITY_LIST
-        )
+        return self.prefetch_related("proof").exclude(proof__owner_consumption=True)
 
     def has_type_group_consumption(self):
         return self.prefetch_related("proof").filter(
-            proof__type__in=proof_constants.TYPE_GROUP_CONSUMPTION_LIST
+            proof__type__in=proof_constants.TYPE_GROUP_CONSUMPTION_LIST,
+            proof__owner_consumption=True,
         )
 
     def with_extra_fields(self):

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -22,6 +22,9 @@ from open_prices.users.models import User
 class PriceQuerySetTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.proof_receipt = ProofFactory(
+            type=proof_constants.TYPE_RECEIPT, owner_consumption=True
+        )
         PriceFactory(
             type=price_constants.TYPE_PRODUCT,
             price=5,
@@ -32,6 +35,7 @@ class PriceQuerySetTest(TestCase):
             type=price_constants.TYPE_PRODUCT, price=8, source="Open Prices Web App"
         )
         PriceFactory(
+            proof_id=cls.proof_receipt.id,
             type=price_constants.TYPE_CATEGORY,
             category_tag="en:apples",
             price_per=price_constants.PRICE_PER_UNIT,
@@ -54,6 +58,14 @@ class PriceQuerySetTest(TestCase):
     def test_has_type_category(self):
         self.assertEqual(Price.objects.count(), 3)
         self.assertEqual(Price.objects.has_type_category().count(), 1)
+
+    def test_has_type_group_community(self):
+        self.assertEqual(Price.objects.count(), 3)
+        self.assertEqual(Price.objects.has_type_group_community().count(), 2)
+
+    def test_has_type_group_consumption(self):
+        self.assertEqual(Price.objects.count(), 3)
+        self.assertEqual(Price.objects.has_type_group_consumption().count(), 1)
 
     def with_extra_fields(self):
         self.assertEqual(Price.objects.count(), 3)

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -32,10 +32,12 @@ class ProofQuerySet(models.QuerySet):
         return self.filter(type__in=proof_constants.TYPE_GROUP_SINGLE_SHOP_LIST)
 
     def has_type_group_community(self):
-        return self.filter(type__in=proof_constants.TYPE_GROUP_COMMUNITY_LIST)
+        return self.exclude(owner_consumption=True)
 
     def has_type_group_consumption(self):
-        return self.filter(type__in=proof_constants.TYPE_GROUP_CONSUMPTION_LIST)
+        return self.filter(
+            type__in=proof_constants.TYPE_GROUP_CONSUMPTION_LIST, owner_consumption=True
+        )
 
     def has_prices(self):
         return self.filter(price_count__gt=0)

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -54,31 +54,42 @@ LOCATION_OSM_NODE_6509705997 = {
 class ProofQuerySetTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.proof_without_price = ProofFactory(
+        cls.proof_without_price_1 = ProofFactory(
             type=proof_constants.TYPE_PRICE_TAG, source="Open Prices Web App"
+        )
+        cls.proof_without_price_2 = ProofFactory(
+            type=proof_constants.TYPE_RECEIPT, source="Open Prices Web App"
         )
         cls.proof_with_price = ProofFactory(type=proof_constants.TYPE_GDPR_REQUEST)
         PriceFactory(proof_id=cls.proof_with_price.id, price=1.0)
 
     def test_has_type_single_shop(self):
-        self.assertEqual(Proof.objects.count(), 2)
-        self.assertEqual(Proof.objects.has_type_single_shop().count(), 1)
+        self.assertEqual(Proof.objects.count(), 3)
+        self.assertEqual(Proof.objects.has_type_single_shop().count(), 2)
+
+    def test_has_type_group_community(self):
+        self.assertEqual(Proof.objects.count(), 3)
+        self.assertEqual(Proof.objects.has_type_group_community().count(), 1)
+
+    def test_has_type_group_consumption(self):
+        self.assertEqual(Proof.objects.count(), 3)
+        self.assertEqual(Proof.objects.has_type_group_consumption().count(), 2)
 
     def test_has_prices(self):
-        self.assertEqual(Proof.objects.count(), 2)
+        self.assertEqual(Proof.objects.count(), 3)
         self.assertEqual(Proof.objects.has_prices().count(), 1)
 
     def with_extra_fields(self):
-        self.assertEqual(Proof.objects.count(), 2)
+        self.assertEqual(Proof.objects.count(), 3)
         self.assertEqual(
             Proof.objects.with_extra_fields()
             .filter(source_annotated=constants.SOURCE_WEB)
             .count(),
-            1,
+            2,
         )
 
     def test_with_stats(self):
-        proof = Proof.objects.with_stats().get(id=self.proof_without_price.id)
+        proof = Proof.objects.with_stats().get(id=self.proof_without_price_1.id)
         self.assertEqual(proof.price_count_annotated, 0)
         self.assertEqual(proof.price_count, 0)
         proof = Proof.objects.with_stats().get(id=self.proof_with_price.id)

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -60,27 +60,34 @@ class ProofQuerySetTest(TestCase):
         cls.proof_without_price_2 = ProofFactory(
             type=proof_constants.TYPE_RECEIPT, source="Open Prices Web App"
         )
-        cls.proof_with_price = ProofFactory(type=proof_constants.TYPE_GDPR_REQUEST)
+        cls.proof_without_price_3 = ProofFactory(
+            type=proof_constants.TYPE_RECEIPT,
+            owner_consumption=True,
+            source="Open Prices Web App",
+        )
+        cls.proof_with_price = ProofFactory(
+            type=proof_constants.TYPE_GDPR_REQUEST, owner_consumption=True
+        )
         PriceFactory(proof_id=cls.proof_with_price.id, price=1.0)
 
     def test_has_type_single_shop(self):
-        self.assertEqual(Proof.objects.count(), 3)
-        self.assertEqual(Proof.objects.has_type_single_shop().count(), 2)
+        self.assertEqual(Proof.objects.count(), 4)
+        self.assertEqual(Proof.objects.has_type_single_shop().count(), 3)
 
     def test_has_type_group_community(self):
-        self.assertEqual(Proof.objects.count(), 3)
-        self.assertEqual(Proof.objects.has_type_group_community().count(), 1)
+        self.assertEqual(Proof.objects.count(), 4)
+        self.assertEqual(Proof.objects.has_type_group_community().count(), 2)
 
     def test_has_type_group_consumption(self):
-        self.assertEqual(Proof.objects.count(), 3)
+        self.assertEqual(Proof.objects.count(), 4)
         self.assertEqual(Proof.objects.has_type_group_consumption().count(), 2)
 
     def test_has_prices(self):
-        self.assertEqual(Proof.objects.count(), 3)
+        self.assertEqual(Proof.objects.count(), 4)
         self.assertEqual(Proof.objects.has_prices().count(), 1)
 
     def with_extra_fields(self):
-        self.assertEqual(Proof.objects.count(), 3)
+        self.assertEqual(Proof.objects.count(), 4)
         self.assertEqual(
             Proof.objects.with_extra_fields()
             .filter(source_annotated=constants.SOURCE_WEB)

--- a/open_prices/stats/tests.py
+++ b/open_prices/stats/tests.py
@@ -131,7 +131,7 @@ class TotalStatsTest(TestCase):
         self.assertEqual(self.total_stats.price_currency_count, 1)
         self.assertEqual(self.total_stats.price_year_count, 3)  # None included
         self.assertEqual(self.total_stats.price_location_country_count, 1)
-        self.assertEqual(self.total_stats.price_type_group_community_count, 1)
+        self.assertEqual(self.total_stats.price_type_group_community_count, 2)
         self.assertEqual(self.total_stats.price_type_group_consumption_count, 1)
         self.assertEqual(self.total_stats.price_source_web_count, 1)
         self.assertEqual(self.total_stats.price_source_mobile_count, 0)

--- a/open_prices/stats/tests.py
+++ b/open_prices/stats/tests.py
@@ -57,11 +57,13 @@ class TotalStatsTest(TestCase):
             location_osm_id=cls.location_2.osm_id,
             location_osm_type=cls.location_2.osm_type,
             currency="EUR",
+            owner_consumption=True,
             owner=cls.user_2.user_id,
         )
         cls.proof_gdpr_request = ProofFactory(
             type=proof_constants.TYPE_GDPR_REQUEST,
             currency="EUR",
+            owner_consumption=True,
             owner=cls.user_2.user_id,
             source="API",
         )

--- a/open_prices/users/tests.py
+++ b/open_prices/users/tests.py
@@ -56,6 +56,7 @@ class UserPropertyTest(TestCase):
         cls.proof_2 = ProofFactory(
             type=proof_constants.TYPE_GDPR_REQUEST,
             currency="USD",
+            owner_consumption=True,
             owner=cls.user_1.user_id,
         )
         PriceFactory(


### PR DESCRIPTION
### What

We introduced type groups in #726.
But with the new `Proof.owner_consumption` field (see #750), we need to manage the case where some RECEIPTs go in the community stats (instead of consumption)