### PR TITLE
refactor(Price tags): matching script: fix script for category_tag. add tests

### DIFF
--- a/open_prices/proofs/management/commands/match_price_tags_with_existing_prices.py
+++ b/open_prices/proofs/management/commands/match_price_tags_with_existing_prices.py
@@ -2,6 +2,7 @@ from collections import Counter
 
 from django.core.management.base import BaseCommand
 
+from open_prices.prices import constants as price_constants
 from open_prices.proofs.models import PriceTag, Proof
 from open_prices.proofs.utils import (
     match_category_price_tag_with_category_price,
@@ -59,16 +60,22 @@ class Command(BaseCommand):
                             if price.price_tags.count() > 0:
                                 continue
                             # match product price
-                            elif match_product_price_tag_with_product_price(
-                                price_tag, price
+                            elif (
+                                price.type == price_constants.TYPE_PRODUCT
+                                and match_product_price_tag_with_product_price(
+                                    price_tag, price
+                                )
                             ):
                                 price_tag.price_id = price.id
                                 price_tag.status = 1
                                 price_tag.save()
                                 break
                             # match category price
-                            elif match_category_price_tag_with_category_price(
-                                price_tag, price
+                            elif (
+                                price.type == price_constants.TYPE_CATEGORY
+                                and match_category_price_tag_with_category_price(
+                                    price_tag, price
+                                )
                             ):
                                 price_tag.price_id = price.id
                                 price_tag.status = 1

--- a/open_prices/proofs/utils.py
+++ b/open_prices/proofs/utils.py
@@ -9,7 +9,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile, TemporaryUpload
 from PIL import Image, ImageOps
 
 from open_prices.common import utils
-from open_prices.prices.constants import TYPE_CATEGORY, TYPE_PRODUCT
+from open_prices.prices import constants as price_constants
 from open_prices.prices.models import Price
 from open_prices.proofs.models import PriceTag
 
@@ -159,7 +159,7 @@ def match_product_price_tag_with_product_price(
     price_tag: PriceTag, price: Price
 ) -> bool:
     """
-    Match on barcode and price.
+    Match on product_code ("barcode") and price.
     """
     price_tag_prediction_data = price_tag.predictions.first().data
     price_tag_prediction_barcode = price_tag_prediction_data.get("barcode")
@@ -168,7 +168,7 @@ def match_product_price_tag_with_product_price(
     )
     price_tag_prediction_price = price_tag_prediction_data.get("price")
     return (
-        price.type == TYPE_PRODUCT
+        price.type == price_constants.TYPE_PRODUCT
         and (price.product_code == price_tag_prediction_barcode)
         and utils.match_decimal_with_float(price.price, price_tag_prediction_price)
     )
@@ -178,14 +178,14 @@ def match_category_price_tag_with_category_price(
     price_tag: PriceTag, price: Price
 ) -> bool:
     """
-    Match on product (category_tag) and price.
+    Match on category_tag ("product") and price.
     """
     price_tag_prediction_data = price_tag.predictions.first().data
     price_tag_prediction_product = price_tag_prediction_data.get("product")
     price_tag_prediction_price = price_tag_prediction_data.get("price")
     return (
-        price.type == TYPE_CATEGORY
-        and (price.product_code == price_tag_prediction_product)
+        price.type == price_constants.TYPE_CATEGORY
+        and (price.category_tag == price_tag_prediction_product)
         and utils.match_decimal_with_float(price.price, price_tag_prediction_price)
     )
 


### PR DESCRIPTION
### What

Following #650

- fix a typo that probably didn't allow to match any TYPE_CATEGORY prices
- add tests (following tests on the price matching function: https://github.com/openfoodfacts/open-prices/commit/2f55f534e7c4e94278ea61dc25a944c88c7107f0)