### PR TITLE
feat(Challenges): set the price tag on price create (if the price belongs to an ongoing challenge)

### DIFF
--- a/open_prices/prices/tasks.py
+++ b/open_prices/prices/tasks.py
@@ -1,0 +1,16 @@
+from open_prices.challenges.models import Challenge
+from open_prices.prices.models import Price
+
+
+def update_tags(price: Price):
+    changes = False
+    # check if the price belongs to an ongoing challenge
+    challenge_qs = Challenge.objects.is_ongoing()
+    if challenge_qs.exists():
+        for challenge in challenge_qs:
+            if price.in_challenge(challenge):
+                if challenge.tag not in price.tags:
+                    price.tags.append(challenge.tag)
+                    changes = True
+    if changes:
+        price.save(update_fields=["tags"])

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -133,7 +133,7 @@ class PriceQuerySetTest(TestCase):
         )
 
 
-class PriceChallengeQuerySetAndPropertyTest(TestCase):
+class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.product_8001505005707 = ProductFactory(
@@ -180,15 +180,18 @@ class PriceChallengeQuerySetAndPropertyTest(TestCase):
         )
 
     def test_in_challenge_property(self):
-        self.assertEqual(self.price_11.in_challenge(self.challenge_ongoing), False)
-        self.assertEqual(self.price_12.in_challenge(self.challenge_ongoing), True)
-        self.assertEqual(self.price_13.in_challenge(self.challenge_ongoing), False)
-        self.assertEqual(self.price_21.in_challenge(self.challenge_ongoing), False)
-        self.assertEqual(self.price_22.in_challenge(self.challenge_ongoing), True)
-        self.assertEqual(self.price_23.in_challenge(self.challenge_ongoing), False)
-        self.assertEqual(self.price_31.in_challenge(self.challenge_ongoing), False)
-        self.assertEqual(self.price_32.in_challenge(self.challenge_ongoing), False)
-        self.assertEqual(self.price_33.in_challenge(self.challenge_ongoing), False)
+        for price in Price.objects.all():
+            if price in [self.price_12, self.price_22]:
+                self.assertEqual(price.in_challenge(self.challenge_ongoing), True)
+            else:
+                self.assertEqual(price.in_challenge(self.challenge_ongoing), False)
+
+    def test_on_create_signal(self):
+        for price in Price.objects.all():
+            if price in [self.price_12, self.price_22]:
+                self.assertIn(f"challenge-{self.challenge_ongoing.id}", price.tags)
+            else:
+                self.assertNotIn(f"challenge-{self.challenge_ongoing.id}", price.tags)
 
 
 class PriceModelSaveTest(TestCase):


### PR DESCRIPTION
### What

Following #807 (new `Price.tags` field)

New signal on price create, to set any ongoing challenge tag