### PR TITLE
refactor(Challenges): new Proof queryset & property to filter on the ones part of a challenge

### DIFF
--- a/open_prices/challenges/tests.py
+++ b/open_prices/challenges/tests.py
@@ -191,6 +191,7 @@ class ChallengePropertyTest(TestCase):
             PriceFactory(
                 product_code="8001505005707", product=cls.product_8001505005707
             )
+        # create the challenge afterwards
         cls.challenge_ongoing = ChallengeFactory(
             is_published=True,
             start_date="2024-12-30",

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -142,16 +142,16 @@ class PriceQuerySetTest(TestCase):
 class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.product_8001505005707 = ProductFactory(
-            **PRODUCT_8001505005707
-        )  # in challenge
-        cls.product_8850187002197 = ProductFactory(**PRODUCT_8850187002197)
         cls.challenge_ongoing = ChallengeFactory(
             is_published=True,
             start_date="2024-12-30",
             end_date="2025-01-30",
             categories=["en:breakfasts"],
         )
+        cls.product_8001505005707 = ProductFactory(
+            **PRODUCT_8001505005707
+        )  # in challenge
+        cls.product_8850187002197 = ProductFactory(**PRODUCT_8850187002197)
         with freeze_time("2025-01-01"):  # during the challenge
             cls.price_11 = PriceFactory()
             cls.price_12 = PriceFactory(

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -10,6 +10,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django_q.tasks import async_task
 
+from open_prices.challenges.models import Challenge
 from open_prices.common import constants, utils
 from open_prices.locations import constants as location_constants
 from open_prices.proofs import constants as proof_constants
@@ -73,6 +74,11 @@ class ProofQuerySet(models.QuerySet):
 
     def has_tag(self, tag: str):
         return self.filter(tags__contains=[tag])
+
+    def in_challenge(self, challenge: Challenge):
+        return self.select_related("prices").filter(
+            prices__tags__contains=[challenge.tag]
+        )
 
 
 class Proof(models.Model):

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -398,6 +398,9 @@ class Proof(models.Model):
             return True
         return False
 
+    def in_challenge(self, challenge: Challenge):
+        return self.prices.filter(tags__contains=[challenge.tag]).exists()
+
 
 @receiver(signals.post_save, sender=Proof)
 def proof_post_save_run_ocr(sender, instance, created, **kwargs):

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -9,13 +9,16 @@ import numpy as np
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
+from freezegun import freeze_time
 from PIL import Image
 
+from open_prices.challenges.factories import ChallengeFactory
 from open_prices.common import constants
 from open_prices.locations import constants as location_constants
 from open_prices.locations.factories import LocationFactory
 from open_prices.prices import constants as price_constants
 from open_prices.prices.factories import PriceFactory
+from open_prices.products.factories import ProductFactory
 from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.factories import (
     PriceTagFactory,
@@ -43,6 +46,24 @@ from open_prices.proofs.utils import (
     match_receipt_item_with_price,
     select_proof_image_dir,
 )
+
+PRODUCT_8001505005707 = {
+    "code": "8001505005707",
+    "product_name": "Nocciolata",
+    "categories_tags": ["en:breakfasts", "en:spreads"],
+    "labels_tags": ["en:no-gluten", "en:organic"],
+    "brands_tags": ["rigoni-di-asiago"],
+    "price_count": 15,
+}
+
+PRODUCT_8850187002197 = {
+    "code": "8850187002197",
+    "product_name": "Riz 20 kg",
+    "categories_tags": ["en:rices"],
+    "labels_tags": [],
+    "brands_tags": ["royal-umbrella"],
+    "price_count": 10,
+}
 
 LOCATION_OSM_NODE_652825274 = {
     "type": location_constants.TYPE_OSM,
@@ -124,6 +145,40 @@ class ProofQuerySetTest(TestCase):
         self.assertEqual(Proof.objects.count(), 4)
         self.assertEqual(Proof.objects.has_tag("challenge-1").count(), 1)
         self.assertEqual(Proof.objects.has_tag("unknown").count(), 0)
+
+
+class ProofChallengeQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.challenge_ongoing = ChallengeFactory(
+            is_published=True,
+            start_date="2024-12-30",
+            end_date="2025-01-30",
+            categories=["en:breakfasts"],
+        )
+        cls.proof_in_challenge = ProofFactory()
+        cls.proof_not_in_challenge = ProofFactory()
+        cls.product_8001505005707 = ProductFactory(
+            **PRODUCT_8001505005707
+        )  # in challenge
+        cls.product_8850187002197 = ProductFactory(**PRODUCT_8850187002197)
+        with freeze_time("2025-01-01"):  # during the challenge
+            PriceFactory(proof=cls.proof_not_in_challenge)
+            PriceFactory(
+                product_code="8001505005707",
+                product=cls.product_8001505005707,
+                proof=cls.proof_in_challenge,
+            )
+            PriceFactory(
+                product_code="8850187002197", product=cls.product_8850187002197
+            )
+
+    def test_in_challenge(self):
+        self.assertEqual(Proof.objects.count(), 2)
+        from open_prices.prices.models import Price
+
+        print(Price.objects.values_list("tags", flat=True))
+        self.assertEqual(Proof.objects.in_challenge(self.challenge_ongoing).count(), 1)
 
 
 class ProofModelSaveTest(TestCase):

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -147,7 +147,7 @@ class ProofQuerySetTest(TestCase):
         self.assertEqual(Proof.objects.has_tag("unknown").count(), 0)
 
 
-class ProofChallengeQuerySetTest(TestCase):
+class ProofChallengeQuerySetAndPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.challenge_ongoing = ChallengeFactory(
@@ -173,12 +173,17 @@ class ProofChallengeQuerySetTest(TestCase):
                 product_code="8850187002197", product=cls.product_8850187002197
             )
 
-    def test_in_challenge(self):
+    def test_in_challenge_queryset(self):
         self.assertEqual(Proof.objects.count(), 2)
-        from open_prices.prices.models import Price
-
-        print(Price.objects.values_list("tags", flat=True))
         self.assertEqual(Proof.objects.in_challenge(self.challenge_ongoing).count(), 1)
+
+    def test_in_challenge_property(self):
+        self.assertEqual(
+            self.proof_in_challenge.in_challenge(self.challenge_ongoing), True
+        )
+        self.assertEqual(
+            self.proof_not_in_challenge.in_challenge(self.challenge_ongoing), False
+        )
 
 
 class ProofModelSaveTest(TestCase):


### PR DESCRIPTION
### What

Following the addition of `Proof.tags` in #817 

- new Proof queryset `in_challenge` (with tests) (similar to #808)
- new Proof property `in_challenge` (with tests) (similar to #810)
