### PR TITLE
feat(Proofs): API: new filter by tags (contains)

### DIFF
--- a/open_prices/api/proofs/filters.py
+++ b/open_prices/api/proofs/filters.py
@@ -35,6 +35,9 @@ class ProofFilter(django_filters.FilterSet):
     prediction_count__lte = django_filters.NumberFilter(
         field_name="price_count", lookup_expr="lte"
     )
+    tags__contains = django_filters.CharFilter(
+        field_name="tags", lookup_expr="icontains"
+    )
     created__gte = django_filters.DateTimeFilter(
         field_name="created", lookup_expr="gte"
     )

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -125,6 +125,7 @@ class ProofListFilterApiTest(TestCase):
             type=proof_constants.TYPE_PRICE_TAG,
             price_count=50,
             owner=cls.user_session.user.user_id,
+            tags=["challenge-1"],
         )
 
     def test_proof_list_filter_by_type(self):
@@ -155,6 +156,14 @@ class ProofListFilterApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 2)
         self.assertEqual(response.data["items"][0]["price_count"], 15)
+
+    def test_price_list_filter_by_tags(self):
+        self.assertEqual(Proof.objects.count(), 3)
+        # tags
+        url = self.url + "?tags__contains=challenge-1"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["tags"], ["challenge-1"])
 
 
 class ProofDetailApiTest(TestCase):


### PR DESCRIPTION
### What

Following #817, and similar to #813

We allow filtering on the new Proof.tags field