### PR TITLE
refactor(Challenges): set the price's proof tag on price create (if the price belongs to an ongoing challenge)

### DIFF
--- a/open_prices/prices/tasks.py
+++ b/open_prices/prices/tasks.py
@@ -9,8 +9,12 @@ def update_tags(price: Price):
     if challenge_qs.exists():
         for challenge in challenge_qs:
             if price.in_challenge(challenge):
+                # update the price
                 success = price.set_tag(challenge.tag, save=False)
                 if success:
                     changes = True
+                # update the price's proof
+                if price.proof:
+                    success = price.proof.set_tag(challenge.tag, save=True)
     if changes:
         price.save(update_fields=["tags"])

--- a/open_prices/prices/tasks.py
+++ b/open_prices/prices/tasks.py
@@ -15,6 +15,6 @@ def update_tags(price: Price):
                     changes = True
                 # update the price's proof
                 if price.proof:
-                    success = price.proof.set_tag(challenge.tag, save=True)
+                    price.proof.set_tag(challenge.tag, save=True)
     if changes:
         price.save(update_fields=["tags"])

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -193,7 +193,7 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
                 self.assertEqual(price.in_challenge(self.challenge_ongoing), False)
 
     def test_on_create_signal(self):
-        for price in Price.objects.all():
+        for price in Price.objects.all():  # refresh_from_db
             if price in [self.price_12, self.price_22]:
                 self.assertIn(f"challenge-{self.challenge_ongoing.id}", price.tags)
             else:

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -185,6 +185,16 @@ class ProofChallengeQuerySetAndPropertyTest(TestCase):
             self.proof_not_in_challenge.in_challenge(self.challenge_ongoing), False
         )
 
+    def test_on_price_create_signal(self):
+        self.proof_in_challenge.refresh_from_db()
+        self.proof_not_in_challenge.refresh_from_db()
+        self.assertIn(
+            f"challenge-{self.challenge_ongoing.id}", self.proof_in_challenge.tags
+        )
+        self.assertNotIn(
+            f"challenge-{self.challenge_ongoing.id}", self.proof_not_in_challenge.tags
+        )
+
 
 class ProofModelSaveTest(TestCase):
     @classmethod


### PR DESCRIPTION
### What

Following #814 (new `Proof.tags` field)
Following #811, but this time for proofs

We use the price create signal: if the price is part of the challenge, then the proof is as well
