### PR TITLE
feat(Price Tag): predictions: set price_tag tags on prediction creation

### DIFF
--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -795,6 +795,20 @@ def price_tag_prediction_post_create_increment_counts(
             )
 
 
+@receiver(signals.post_save, sender=PriceTagPrediction)
+def price_tag_prediction_post_create_update_price_tag_tags(
+    sender, instance, created, **kwargs
+):
+    if created:
+        if instance.price_tag_id:
+            if instance.has_predicted_barcode_valid():
+                instance.price_tag.set_tag("prediction-barcode-valid", save=True)
+                if instance.has_predicted_barcode_valid_and_product_exists():
+                    instance.price_tag.set_tag("prediction-product-exists", save=True)
+            if instance.has_predicted_category_tag_valid():
+                instance.price_tag.set_tag("prediction-category-tag-valid", save=True)
+
+
 class ReceiptItemQuerySet(models.QuerySet):
     def status_unknown(self):
         return self.filter(status=None)

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -710,7 +710,7 @@ class PriceTag(models.Model):
 
     def get_predicted_product(self):
         if self.predictions.exists():
-            return self.predictions.first().data.get("product")
+            return self.predictions.first().data.get("product")  # category_tag
         return None
 
     def get_predicted_product_name(self):
@@ -767,6 +767,15 @@ class PriceTagPrediction(models.Model):
                 return True
         return False
 
+    def has_predicted_product_exists(self):
+        from open_prices.products.models import Product
+
+        if self.data.get("barcode"):
+            barcode = self.data.get("barcode")
+            if Product.objects.filter(code=barcode).exists():
+                return True
+        return False
+
     def has_predicted_barcode_valid_and_product_exists(self):
         from open_prices.products.models import Product
 
@@ -803,8 +812,8 @@ def price_tag_prediction_post_create_update_price_tag_tags(
         if instance.price_tag_id:
             if instance.has_predicted_barcode_valid():
                 instance.price_tag.set_tag("prediction-barcode-valid", save=True)
-                if instance.has_predicted_barcode_valid_and_product_exists():
-                    instance.price_tag.set_tag("prediction-product-exists", save=True)
+            if instance.has_predicted_product_exists():
+                instance.price_tag.set_tag("prediction-product-exists", save=True)
             if instance.has_predicted_category_tag_valid():
                 instance.price_tag.set_tag("prediction-category-tag-valid", save=True)
 

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -1176,6 +1176,15 @@ class PriceTagPredictionTest(TestCase):
         )
         self.assertFalse(self.price_tag_empty_prediction.has_predicted_barcode_valid())
 
+    def test_has_predicted_product_exists(self):
+        self.assertTrue(
+            self.price_tag_product_prediction.has_predicted_product_exists()
+        )
+        self.assertFalse(
+            self.price_tag_category_prediction.has_predicted_product_exists()
+        )
+        self.assertFalse(self.price_tag_empty_prediction.has_predicted_product_exists())
+
     def test_has_predicted_barcode_valid_and_product_exists(self):
         self.assertTrue(
             self.price_tag_product_prediction.has_predicted_barcode_valid_and_product_exists()

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -1033,6 +1033,7 @@ class PriceTagModelTest(TestCase):
 class PriceTagPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
+        ProductFactory(**PRODUCT_8001505005707)
         cls.proof = ProofFactory(type=proof_constants.TYPE_PRICE_TAG)
         cls.price_tag_product = PriceTagFactory(
             bounding_box=[0.1, 0.1, 0.2, 0.2],
@@ -1100,7 +1101,7 @@ class PriceTagPropertyTest(TestCase):
         self.assertEqual(self.price_tag_empty.get_predicted_product_name(), None)
 
 
-class PriceTagPredictionPropertyTest(TestCase):
+class PriceTagPredictionTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         ProductFactory(**PRODUCT_8001505005707)
@@ -1138,10 +1139,35 @@ class PriceTagPredictionPropertyTest(TestCase):
             proof=cls.proof,
         )
         cls.price_tag_empty_prediction = PriceTagPrediction.objects.create(
-            price_tag=cls.price_tag_category,
+            price_tag=cls.price_tag_empty,
             type=proof_constants.PRICE_TAG_EXTRACTION_TYPE,
             data={},
         )
+        cls.price_tag_without = PriceTagFactory(
+            bounding_box=[0.4, 0.4, 0.5, 0.5],
+            proof=cls.proof,
+        )
+
+    def test_on_create_signal(self):
+        # price_tag.prediction_count
+        for price_tag in PriceTag.objects.all():  # refresh_from_db
+            if price_tag in [self.price_tag_without]:
+                self.assertEqual(price_tag.prediction_count, 0)
+            else:
+                self.assertEqual(price_tag.prediction_count, 1)
+        # price_tag.tags
+        self.assertIn("prediction-barcode-valid", self.price_tag_product.tags)
+        self.assertIn("prediction-product-exists", self.price_tag_product.tags)
+        self.assertNotIn("prediction-category-tag-valid", self.price_tag_product.tags)
+        self.assertNotIn("prediction-barcode-valid", self.price_tag_category.tags)
+        self.assertNotIn("prediction-product-exists", self.price_tag_category.tags)
+        self.assertIn("prediction-category-tag-valid", self.price_tag_category.tags)
+        self.assertNotIn("prediction-barcode-valid", self.price_tag_empty.tags)
+        self.assertNotIn("prediction-product-exists", self.price_tag_empty.tags)
+        self.assertNotIn("prediction-category-tag-valid", self.price_tag_empty.tags)
+        self.assertNotIn("prediction-barcode-valid", self.price_tag_without.tags)
+        self.assertNotIn("prediction-product-exists", self.price_tag_without.tags)
+        self.assertNotIn("prediction-category-tag-valid", self.price_tag_without.tags)
 
     def test_has_predicted_barcode_valid(self):
         self.assertTrue(self.price_tag_product_prediction.has_predicted_barcode_valid())


### PR DESCRIPTION
### What

Following #838

We use a signal on `PriceTagPrediction` creation, and update the `PriceTag.tags` field depending on rules defined in the previous PR