### PR TITLE
fix: normalize `price.label_tags` taxonomized values

### DIFF
--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -28,6 +28,9 @@ from open_prices.users.models import User
 # Taxonomy mapping generation takes ~200ms, so we cache it to avoid
 # recomputing it for each request.
 _cached_create_taxonomy_mapping = functools.lru_cache()(create_taxonomy_mapping)
+# Also cache the get_taxonomy function to avoid reading from disk at each
+# request.
+_cached_get_taxonomy = functools.lru_cache()(get_taxonomy)
 
 
 class PriceQuerySet(models.QuerySet):
@@ -317,24 +320,10 @@ class Price(models.Model):
                     "type",
                     "Should be set to 'CATEGORY' if `category_tag` is filled",
                 )
-            category_taxonomy = get_taxonomy("category")
-            # category_tag can be provided by the mobile app in any language,
-            # with language prefix (ex: `fr: Boissons`). We need to map it to
-            # the canonical id (ex: `en:beverages`) to store it in the
-            # database.
-            # The `map_to_canonical_id` function maps the value (ex:
-            # `fr: Boissons`) to the canonical id (ex: `en:beverages`).
-            # We use the cached version of this function to avoid
-            # creating it multiple times.
-            # If the entry does not exist in the taxonomy, category_tag will
-            # be set to the tag version of the value (ex: `fr:boissons`).
-            category_taxonomy_mapping = _cached_create_taxonomy_mapping(
-                category_taxonomy
-            )
             try:
-                category_mapped_tags = map_to_canonical_id(
-                    category_taxonomy_mapping, [self.category_tag]
-                )
+                self.category_tag = normalize_taxonomized_tags(
+                    "category", [self.category_tag]
+                )[0]
             except ValueError as e:
                 # The value is not language-prefixed
                 validation_errors = utils.add_validation_error(
@@ -342,10 +331,6 @@ class Price(models.Model):
                     "category_tag",
                     str(e),
                 )
-            else:
-                # Set the canonical id (or taggified version) as the
-                # category_tag
-                self.category_tag = category_mapped_tags[self.category_tag]
             if self.labels_tags:
                 if not isinstance(self.labels_tags, list):
                     validation_errors = utils.add_validation_error(
@@ -354,14 +339,16 @@ class Price(models.Model):
                         "Should be a list",
                     )
                 else:
-                    labels_taxonomy = get_taxonomy("label")
-                    for label_tag in self.labels_tags:
-                        if label_tag not in labels_taxonomy:
-                            validation_errors = utils.add_validation_error(
-                                validation_errors,
-                                "labels_tags",
-                                f"Invalid label tag: label '{label_tag}' does not exist in the taxonomy",
-                            )
+                    try:
+                        self.labels_tags = normalize_taxonomized_tags(
+                            "label", self.labels_tags
+                        )
+                    except ValueError as e:
+                        validation_errors = utils.add_validation_error(
+                            validation_errors,
+                            "labels_tags",
+                            str(e),
+                        )
             if self.origins_tags:
                 if not isinstance(self.origins_tags, list):
                     validation_errors = utils.add_validation_error(
@@ -370,23 +357,16 @@ class Price(models.Model):
                         "Should be a list",
                     )
                 else:
-                    origins_taxonomy = get_taxonomy("origin")
-                    origins_taxonomy_mapping = _cached_create_taxonomy_mapping(
-                        origins_taxonomy
-                    )
                     try:
-                        origins_mapped_tags = map_to_canonical_id(
-                            origins_taxonomy_mapping, self.origins_tags
+                        self.origins_tags = normalize_taxonomized_tags(
+                            "origin", self.origins_tags
                         )
                     except ValueError as e:
-                        # The value is not language-prefixed
                         validation_errors = utils.add_validation_error(
                             validation_errors,
                             "origins_tags",
                             str(e),
                         )
-                    else:
-                        self.origins_tags = list(origins_mapped_tags.values())
         else:
             validation_errors = utils.add_validation_error(
                 validation_errors,
@@ -711,3 +691,40 @@ def price_post_delete_decrement_counts(sender, instance, **kwargs):
         Location.objects.filter(id=instance.location.id).update(
             price_count=F("price_count") - 1
         )
+
+
+def normalize_taxonomized_tags(taxonomy_type: str, value_tags: list[str]) -> list[str]:
+    """Normalizes a list of tags based on the taxonomy type.
+
+    :param taxonomy_type: The type of taxonomy ('category', 'label', or
+        'origin').
+    :param value_tags: A list of tag values to normalize (e.g.,
+        ["fr: Boissons"]).
+    :raises RuntimeError: If the taxonomy type is not one of 'category',
+        'label', or 'origin'
+    :raises ValueError: If the value_tag could not be mapped to a canonical ID.
+    :return: The normalized tags (e.g., ["en:beverages"]). The order of the
+        tags is the same as the input list.
+    """
+    if taxonomy_type not in ("category", "label", "origin"):
+        raise RuntimeError(
+            f"Invalid taxonomy type: {taxonomy_type}. Expected one of 'category', 'label', or 'origin'."
+        )
+
+    # Use the cached version of the get_taxonomy function to avoid
+    # creating it multiple times.
+    category_taxonomy = _cached_get_taxonomy(taxonomy_type)
+    # the tag (category or label tag) can be provided by the mobile app in any
+    # language, with language prefix (ex: `fr: Boissons`).
+    # We need to map it to the canonical id (ex: `en:beverages`) to store it
+    # in the database.
+    # The `map_to_canonical_id` function maps the value (ex:
+    # `fr: Boissons`) to the canonical id (ex: `en:beverages`).
+    # We use the cached version of this function to avoid
+    # creating it multiple times.
+    # If the entry does not exist in the taxonomy, the tag will
+    # be set to the tag version of the value (ex: `fr:boissons`).
+    taxonomy_mapping = _cached_create_taxonomy_mapping(category_taxonomy)
+    mapped_tags = map_to_canonical_id(taxonomy_mapping, value_tags)
+    # Keep the order of the tags as they were provided
+    return [mapped_tags[k] for k in mapped_tags]

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -365,6 +365,32 @@ class PriceModelSaveTest(TestCase):
             )
             self.assertEqual(price.origins_tags, expected_origin_tags)
 
+    def test_price_label_validation(self):
+        for input_labels_tags, expected_labels_tags in [
+            (
+                [
+                    "fr: Nutriscore A",
+                    "fr: Bio",
+                    "es: Comercio justo y orgánico",
+                    "en: Tag To be Created",
+                ],
+                [
+                    "en:nutriscore-grade-a",
+                    "en:organic",
+                    "en:fair-trade-organic",
+                    "en:tag-to-be-created",
+                ],
+            ),
+        ]:
+            price = PriceFactory(
+                type=price_constants.TYPE_CATEGORY,
+                category_tag="en:tomatoes",
+                labels_tags=input_labels_tags,
+                price=3,
+                price_per=price_constants.PRICE_PER_KILOGRAM,
+            )
+            self.assertEqual(price.labels_tags, expected_labels_tags)
+
     def test_price_price_validation(self):
         for PRICE_OK in [0, 5, Decimal("1.5")]:
             PriceFactory(price=PRICE_OK)


### PR DESCRIPTION
The normalization was effective for `category_tag`, `origins_tags` but not for `labels_tags`.
Fixes #855.