### PR TITLE
fix: by default, set `owner_consumption=true` for receipt/GDPR requests

### DIFF
--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -297,6 +297,17 @@ class Proof(models.Model):
                     "receipt_online_delivery_costs",
                     "Can only be set if type RECEIPT",
                 )
+
+        if (
+            self.type in proof_constants.TYPE_GROUP_CONSUMPTION_LIST
+            and self.owner_consumption is None
+        ):
+            # If `owner_consumption` is not set for GDPR or receipt proofs, we
+            # assume that it's a consumption proof. Not many users upload
+            # proofs that are not theirs, and we should have reasonable
+            # defaults.
+            self.owner_consumption = True
+
         # consumption specific rules
         if self.type not in proof_constants.TYPE_GROUP_CONSUMPTION_LIST:
             if self.owner_consumption is not None:

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -110,11 +110,11 @@ class ProofQuerySetTest(TestCase):
 
     def test_has_kind_community(self):
         self.assertEqual(Proof.objects.count(), 4)
-        self.assertEqual(Proof.objects.has_kind_community().count(), 2)
+        self.assertEqual(Proof.objects.has_kind_community().count(), 1)
 
     def test_has_kind_consumption(self):
         self.assertEqual(Proof.objects.count(), 4)
-        self.assertEqual(Proof.objects.has_kind_consumption().count(), 2)
+        self.assertEqual(Proof.objects.has_kind_consumption().count(), 3)
 
     def test_has_prices(self):
         self.assertEqual(Proof.objects.count(), 4)


### PR DESCRIPTION
See issue #750 for context.