### PR TITLE
feat: improve price tag extraction using Gemini

### DIFF
--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -138,7 +138,10 @@ class ProofViewSet(
     def process_with_gemini(self, request: Request) -> Response:
         files = request.FILES.getlist("files")
         sample_files = [PIL.Image.open(file.file) for file in files]
-        labels = [extract_from_price_tag(sample_file) for sample_file in sample_files]
+        labels = [
+            extract_from_price_tag(sample_file).parsed.model_dump()
+            for sample_file in sample_files
+        ]
         return Response({"labels": labels}, status=status.HTTP_200_OK)
 
 

--- a/open_prices/common/google.py
+++ b/open_prices/common/google.py
@@ -58,7 +58,20 @@ def get_genai_client() -> genai.Client:
     return genai.Client()
 
 
-def get_generation_config(response_schema) -> types.GenerateContentConfig:
+def get_generation_config(
+    response_schema: type, thinking_budget: int = -1
+) -> types.GenerateContentConfig:
+    """Return a generation configuration for the Gemini model.
+
+    :param response_schema: The schema for the response. It can be a Pydantic
+        model or a TypeDict.
+    :param thinking_budget: The budget for the thinking process, in tokens.
+        0 is DISABLED. -1 is AUTOMATIC.
+    """
     return types.GenerateContentConfig(
-        response_mime_type="application/json", response_schema=response_schema
+        response_mime_type="application/json",
+        response_schema=response_schema,
+        thinking_config=types.ThinkingConfig(
+            thinking_budget=thinking_budget, include_thoughts=True
+        ),
     )

--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -5,6 +5,7 @@ Proof ML/AI
 - extract data from PriceTags with Gemini
 """
 
+import asyncio
 import base64
 import enum
 import gzip
@@ -12,7 +13,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import typing_extensions as typing
 from django.conf import settings
@@ -20,6 +21,7 @@ from openfoodfacts.ml.image_classification import ImageClassifier
 from openfoodfacts.ml.object_detection import ObjectDetectionRawResult, ObjectDetector
 from openfoodfacts.utils import http_session
 from PIL import Image
+from pydantic import BaseModel, Field
 
 from open_prices.common import google as common_google
 
@@ -48,6 +50,8 @@ PRICE_TAG_DETECTOR_IMAGE_SIZE = 960
 
 
 # TODO: what about other categories?
+# We keep the Products here for now to keep the compatibility with the
+# ReceiptItem model
 class Products(enum.Enum):
     OTHER = "other"
     APPLES = "en:apples"
@@ -135,8 +139,97 @@ class Products(enum.Enum):
     ZUCCHINI = "en:zucchini"
 
 
+class RawCategory(enum.StrEnum):
+    OTHER = "other"
+    APPLES = "en:apples"
+    APRICOTS = "en:apricots"
+    ARTICHOKES = "en:artichokes"
+    ASPARAGUS = "en:asparagus"
+    AUBERGINES = "en:aubergines"
+    AVOCADOS = "en:avocados"
+    BANANAS = "en:bananas"
+    BEETROOT = "en:beetroot"
+    BERRIES = "en:berries"
+    BLACKBERRIES = "en:blackberries"
+    BLUEBERRIES = "en:blueberries"
+    BOK_CHOY = "en:bok-choy"
+    BROCCOLI = "en:broccoli"
+    CABBAGES = "en:cabbages"
+    CARROTS = "en:carrots"
+    CAULIFLOWERS = "en:cauliflowers"
+    CELERY = "en:celery"
+    CELERIAC = "en:celeriac"
+    CELERY_STALK = "en:celery-stalk"
+    CEP_MUSHROOMS = "en:cep-mushrooms"
+    CHANTERELLES = "en:chanterelles"
+    CHARDS = "en:chards"
+    CHERRIES = "en:cherries"
+    CHERRY_TOMATOES = "en:cherry-tomatoes"
+    CHICKPEAS = "en:chickpeas"
+    CHIVES = "en:chives"
+    CLEMENTINES = "en:clementines"
+    COCONUTS = "en:coconuts"
+    CRANBERRIES = "en:cranberries"
+    CUCUMBERS = "en:cucumbers"
+    DATES = "en:dates"
+    ENDIVES = "en:endives"
+    FENNEL_BULBS = "en:fennel-bulbs"
+    FIGS = "en:figs"
+    GARLIC = "en:garlic"
+    GINGER = "en:ginger"
+    GRAPEFRUITS = "en:grapefruits"
+    GRAPES = "en:grapes"
+    GREEN_BEANS = "en:green-beans"
+    GREEN_SWEET_PEPPERS = "en:green-sweet-peppers"
+    KIWIS = "en:kiwis"
+    KAKIS = "en:kakis"
+    LEEKS = "en:leeks"
+    LEMONS = "en:lemons"
+    LETTUCES = "en:lettuces"
+    LIMES = "en:limes"
+    LYCHEES = "en:lychees"
+    MANDARIN_ORANGES = "en:mandarin-oranges"
+    MANGOES = "en:mangoes"
+    MELONS = "en:melons"
+    MUSHROOMS = "en:mushrooms"
+    NECTARINES = "en:nectarines"
+    ONIONS = "en:onions"
+    ORANGES = "en:oranges"
+    PAPAYAS = "en:papayas"
+    PARSNIP = "en:parsnip"
+    PASSION_FRUITS = "en:passion-fruits"
+    PEACHES = "en:peaches"
+    PEARS = "en:pears"
+    PEAS = "en:peas"
+    PEPPERS = "en:peppers"
+    PINEAPPLE = "en:pineapple"
+    PLUMS = "en:plums"
+    POMEGRANATES = "en:pomegranates"
+    POMELOS = "en:pomelos"
+    POTATOES = "en:potatoes"
+    PUMPKINS = "en:pumpkins"
+    RADISHES = "en:radishes"
+    RASPBERRIES = "en:raspberries"
+    RED_BELL_PEPPERS = "en:red-bell-peppers"
+    RED_ONIONS = "en:red-onions"
+    RHUBARBS = "en:rhubarbs"
+    SCALLIONS = "en:scallions"
+    SHALLOTS = "en:shallots"
+    SPINACHS = "en:spinachs"
+    SPROUTS = "en:sprouts"
+    STRAWBERRIES = "en:strawberries"
+    TOMATOES = "en:tomatoes"
+    TURNIP = "en:turnip"
+    WATERMELONS = "en:watermelons"
+    WALNUTS = "en:walnuts"
+    YELLOW_ONIONS = "en:yellow-onions"
+    ZUCCHINI = "en:zucchini"
+    # used for products with barcode, which are not raw products
+    NO_CATEGORY = "no_category"
+
+
 # TODO: what about other origins?
-class Origin(enum.Enum):
+class Origin(enum.StrEnum):
     FRANCE = "en:france"
     ITALY = "en:italy"
     SPAIN = "en:spain"
@@ -149,25 +242,136 @@ class Origin(enum.Enum):
     MEXICO = "en:mexico"
     OTHER = "other"
     UNKNOWN = "unknown"
+    # used for products with barcode, which are not raw products
+    NO_ORIGIN = "no_origin"
 
 
-class Unit(enum.Enum):
+class Unit(enum.StrEnum):
     KILOGRAM = "KILOGRAM"
+    LITER = "LITER"
     UNIT = "UNIT"
 
 
-class Label(typing.TypedDict):
-    product: Products  # category_tag
-    price: float
-    origin: Origin
-    unit: Unit
-    organic: bool
-    barcode: str
-    product_name: str
+class DiscountType(enum.StrEnum):
+    QUANTITY = "QUANTITY"  # example: buy 1 get 1 free
+    SALE = "SALE"  # example: 50% off
+    SEASONAL = "SEASONAL"  # example: Christmas sale
+    LOYALTY_PROGRAM = "LOYALTY_PROGRAM"  # example: 10% off for members
+    EXPIRES_SOON = "EXPIRES_SOON"  # example: 30% off expiring soon
+    PICK_IT_YOURSELF = "PICK_IT_YOURSELF"  # example: 5% off for pick-up
+    SECOND_HAND = "SECOND_HAND"  # example: second hand books or clothes
+    OTHER = "OTHER"
+    NO_DISCOUNT = "NO_DISCOUNT"  # no discount applied
 
 
-class Labels(typing.TypedDict):
-    labels: list[Label]
+class LabelPrice(BaseModel):
+    """One of the price displayed on a price tag.
+
+    For raw products (without barcode), if the price is indicated per weight
+    but is not per kilogram (example: per 100g or per 500g), the price per
+    kilogram should be calculated.
+    """
+
+    price: float = Field(..., description="Price in the local currency")
+    currency: str = Field(
+        ...,
+        description="Currency of the price. Leave empty if unknown. Examples: 'EUR', 'USD', 'GBP'",
+    )
+    price_per: Unit = Field(..., description="Unit of the price.")
+    price_is_discounted: bool = Field(
+        False, description="true if the price is discounted, false otherwise"
+    )
+    discount_type: DiscountType = Field(
+        DiscountType.NO_DISCOUNT,
+        description="The type of discount applied to the price, if any. "
+        "If no discount is applied, this should be set to NO_DISCOUNT.",
+    )
+
+
+class Label(BaseModel):
+    """A label (also called price tag) indicates in a store the price of the
+    product and possibly other information such as the category, price per kg,
+    origin, etc.
+
+    We distinguish between two types of labels:
+
+    - Labels for packaged products, with barcode (type: PRODUCT): these are
+    products that have a barcode, which is usually displayed on the price tag.
+    For this type of label, the category should be set to NO_CATEGORY, the
+    origin should be set to NO_ORIGIN.
+    - Raw products, without barcode (type: CATEGORY): these are usually fruits
+    and vegetables, but it can also be any product sold per weight (kg, 100g,
+    etc.). For this type of label, the category should be set to the
+    corresponding RawCategory, the origin should be set to the country of
+    origin of the product (if indicated) and the barcode should be empty.
+    """
+
+    type: Literal["PRODUCT", "CATEGORY"] = Field(
+        ...,
+        description="The type of product the label is referring to. It should be "
+        "`PRODUCT` for packaged products with barcode, and `CATEGORY` for raw "
+        "products without barcode.",
+    )
+    category: RawCategory = Field(
+        RawCategory.NO_CATEGORY,
+        description="The category of the product. "
+        "If type=PRODUCT, this should be set to the NO_CATEGORY.",
+    )  # category_tag
+    prices: list[LabelPrice] = Field(
+        ...,
+        description="All prices found on the label. Depending on the type of "
+        "price tag, there can be multiple prices displayed. "
+        "For packaged products (type=PRODUCT), the price per unit is the most common one. "
+        "The price per kg is also often included as well. "
+        "For raw products (type=CATEGORY), the price per kg is the most common one. "
+        "There can also be a discount applied to the price. In such case, both "
+        "the original price and the discounted price should be included in the list.",
+    )
+    origin: Origin = Field(
+        ...,
+        description="The country of origin of the product. "
+        "If type=PRODUCT, this should be set to NO_ORIGIN. If type=CATEGORY, this should "
+        "be set to the country of origin of the product, such as France, Italy, Spain, etc.",
+    )
+    organic: bool = Field(
+        ...,
+        description="true if the product is organic, false otherwise. If true, "
+        "there should be evidence on the label suggesting that the product is "
+        "organic, such as the EU organic logo.",
+    )
+    barcode: str = Field(
+        ...,
+        description="The barcode of the product, if available. "
+        "The barcode are usually numbers with 13 (EAN13) or 8 (EAN8) digits. You should "
+        "*NOT* try to decode the barcode stripe (also called modules), but use the "
+        "barcode number displayed on the label. "
+        "If type=CATEGORY, this should be empty.",
+    )
+    product_name: str = Field(
+        ...,
+        description="The name of the product, as displayed on the label. "
+        "For raw products (type=CATEGORY), this is usually the name of the fruit or vegetable. "
+        "For products with barcode (type=PRODUCT), it usually includes the brand, a short "
+        "description of the product, and eventually the quantity. "
+        "examples: 'NOCCIOLATA BIO 650G', 'Simpson Donuts', 'GERBLE BISCUIT PIST ABRICOT160G', "
+        "'Radis Blanc', 'Concombre lisse', 'Courget Butternut', 'Tomatoes', 'Organic Bananas'",
+    )
+    blurriness: float = Field(
+        0.0,
+        description="The blurriness of the label image, from 0.0 (not blurry) to 1.0 (very blurry).",
+        ge=0.0,
+        le=1.0,
+    )
+    truncated: bool = Field(
+        False,
+        description="true if the photo of the price tag is truncated, false otherwise. A photo of a price tag is considered truncated if any of these occurs:\n"
+        "- the barcode (for packaged products) or the product name (for raw products) is not fully visible on the photo\n"
+        "- the price is not fully visible on the photo\n",
+    )
+    is_price_tag: bool = Field(
+        True,
+        description="true if the image is a price tag, false otherwise. If the image seems to come from a receipt or a catalogue, this should be set to false.",
+    )
 
 
 class ReceiptItemType(typing.TypedDict):
@@ -187,76 +391,95 @@ class Receipt(typing.TypedDict):
     items: list[ReceiptItemType]
 
 
-def extract_from_price_tag(image: Image.Image) -> Label:
-    """Extract price tag information from an image.
-
-    :param image: the input Pillow image
-    :return: the extracted information as a dictionary
-    """
-    client = common_google.get_genai_client()
+def preprocess_price_tag(image: Image.Image) -> Image.Image:
     # Gemini model max payload size is 20MB
     # To prevent the payload from being too large, we resize the images
     max_size = 1024
     if image.width > max_size or image.height > max_size:
         image = image.copy()
         image.thumbnail((max_size, max_size))
+    return image
 
-    prompt = (
-        "Here is one picture containing a label. "
-        "Please extract all the following attributes: "
-        "the product category matching product name, the origin category matching country of origin, the price, "
-        "is the product organic, the unit (per KILOGRAM or per UNIT) and the barcode (valid EAN-13 usually). "
-        "I expect a single JSON in your reply, no more, no less. "
-        "If you cannot decode an attribute, set it to an empty string."
-    )
+
+EXTRACT_PRICE_TAG_PROMPT = (
+    "Here is one picture containing a price label, extract information "
+    "from it. If you cannot decode an attribute, set it to an empty string."
+)
+
+
+def extract_from_price_tag(
+    image: Image.Image, thinking_budget: int = -1
+) -> common_google.types.GenerateContentResponse:
+    """Extract price tag information from an image.
+
+    :param image: the input Pillow image. Image preprocessing is done
+        automatically to resize the image if it is too large.
+    :param thinking_budget: the thinking budget for the Gemini model, in
+        tokens. 0 is DISABLED. -1 is AUTOMATIC.
+    :return: the Gemini response
+    """
+    client = common_google.get_genai_client()
+    preprocessed_image = preprocess_price_tag(image)
+
     response = client.models.generate_content(
         model=common_google.GEMINI_MODEL_VERSION,
         contents=[
-            prompt,
+            EXTRACT_PRICE_TAG_PROMPT,
+            preprocessed_image,
+        ],
+        config=common_google.get_generation_config(
+            Label, thinking_budget=thinking_budget
+        ),
+    )
+    return response
+
+
+async def extract_from_price_tag_async(
+    image: Image.Image, thinking_budget: int = -1
+) -> common_google.types.GenerateContentResponse:
+    """Asynchronous version of extract_from_price_tag.
+
+    Image preprocessing (resizing to maximum size) must be done before calling
+    this function.
+
+    :param image: the input Pillow image, already preprocessed.
+    :param thinking_budget: the thinking budget for the Gemini model, in
+        tokens. 0 is DISABLED. -1 is AUTOMATIC.
+    :return: the Gemini response
+    """
+    client = common_google.get_genai_client()
+    response = await client.aio.models.generate_content(
+        model=common_google.GEMINI_MODEL_VERSION,
+        contents=[
+            EXTRACT_PRICE_TAG_PROMPT,
             image,
         ],
-        config=common_google.get_generation_config(Label),
+        config=common_google.get_generation_config(
+            Label, thinking_budget=thinking_budget
+        ),
     )
-    return json.loads(response.text)
+    return response
 
 
-def extract_from_price_tags(images: Image.Image) -> Labels:
+async def extract_from_price_tag_batch(
+    images: list[Image.Image], thinking_budget: int = -1
+) -> list[common_google.types.GenerateContentResponse]:
+    """Extract price tag information from a batch of images.
+
+    This function processes multiple images in parallel using asyncio.
+
+    :param images: a list of Pillow images, already preprocessed (resized).
+    :param thinking_budget: the thinking budget for the Gemini model, in
+        tokens. 0 is DISABLED. -1 is AUTOMATIC.
+    :return: a list of Gemini responses, one for each image
     """
-    Extract price tag information from a list of images.
-
-    Warning:
-    Gemini sometimes skips some images when prediction price tag labels,
-    leading to mismatch between price tag and predictions.
-    Use extract_from_price_tag instead.
-    """
-
-    # Gemini model max payload size is 20MB
-    # To prevent the payload from being too large, we resize the images
-    image_list = []
-    max_size = 1024
-    for image in images:
-        if image.width > max_size or image.height > max_size:
-            resized_image = image.copy()
-            resized_image.thumbnail((max_size, max_size))
-            image_list.append(resized_image)
-        else:
-            image_list.append(image)
-
-    prompt = (
-        f"Here are {len(image_list)} pictures containing a label. "
-        "For each picture of a label, please extract all the following attributes: "
-        "the product category matching product name, the origin category matching country of origin, the price, "
-        "is the product organic, the unit (per KILOGRAM or per UNIT) and the barcode (valid EAN-13 usually). "
-        f"I expect a list of {len(image_list)} labels in your reply, no more, no less. "
-        "If you cannot decode an attribute, set it to an empty string"
-    )
-    client = common_google.get_genai_client()
-    response = client.models.generate_content(
-        model=common_google.GEMINI_MODEL_VERSION,
-        contents=[prompt] + image_list,
-        config=common_google.get_generation_config(Labels),
-    )
-    return json.loads(response.text)
+    responses = []
+    tasks = [
+        extract_from_price_tag_async(image, thinking_budget=thinking_budget)
+        for image in images
+    ]
+    responses = await asyncio.gather(*tasks)
+    return responses
 
 
 def extract_from_receipt(image: Image.Image) -> Receipt:
@@ -451,6 +674,7 @@ def run_and_save_price_tag_extraction(
         return []
 
     predictions = []
+    preprocessed_images = []
     for price_tag in price_tags:
         y_min, x_min, y_max, x_max = price_tag.bounding_box
         image = Image.open(proof.file_path_full)
@@ -461,14 +685,21 @@ def run_and_save_price_tag_extraction(
             y_max * image.height,
         )
         cropped_image = image.crop((left, top, right, bottom))
-        label = extract_from_price_tag(cropped_image)
+        preprocessed_images.append(preprocess_price_tag(cropped_image))
+
+    # We send requests to Gemini in parallel using asyncio
+    # to speed up the extraction process.
+    responses = asyncio.run(
+        extract_from_price_tag_batch(preprocessed_images, thinking_budget=-1)
+    )
+    for price_tag, response in zip(price_tags, responses):
         try:
             prediction = PriceTagPrediction.objects.create(
                 price_tag=price_tag,
                 type=proof_constants.PRICE_TAG_EXTRACTION_TYPE,
                 model_name=common_google.GEMINI_MODEL_NAME,
                 model_version=common_google.GEMINI_MODEL_VERSION,
-                data=label,
+                data=response.parsed.model_dump(),
             )
             predictions.append(prediction)
         except Exception as e:


### PR DESCRIPTION
This PR improves both the speed and accuracy of extraction from price tags.
The speed is improved by sending requests to Gemini in parallel, using an event loop (asyncio).

The performance of the extraction is improved by:
- providing a JSON Schema with detailed descriptions and rules to follow, through Pydantic, to Gemini model
- enabling model reasoning during extraction

I've added the following modifications to the original schema:

- I added a new `type` (`PRODUCT` or `CATEGORY`) to know the price type (same as on Open Prices `price` model)
- If `type=PRODUCT`, wet set `category` to a new value `NO_CATEGORY` and `origin` to a new value `NO_ORIGIN`
- we don't have a `price` field anymore, but a list of `prices`. This allows to extract price values for more complex price tags. Example: we have 2 prices on the price tag, one for fidelity card members, one for the general public. It's also useful to extract the price per kg/l (as often displayed on price tags), to be able to compare it to the theoretical price per kg/l, using OFF data. Finally, it allows us to suggest in the front-end other detected prices, in case the model didn't extract the right value. Another improvement is that for `type=CATEGORY`, if the price is given for 500 g or 100g, we ask the model to convert it to the price per kg (it works well in my tests).
- I added the `blurriness`, `truncated` and `is_price_tag` fields. Adding new fields is cheap, and this data will be useful as a pre-categorization when training specific models.

This new schema obviously breaks the currently used schema, which means we will need to update the front-end as well.
I think we should version the schema of the extraction, so that the front-end doesn't break when we have multiple schema in DB.

Missing from this PR:
- support for VAT-less prices. In Japan, for example, most of the time 2 prices are displayed: with VAT and without.
- creating a new `price` field during Pydantic model export that is the most likely price, with support for some forms of discounted prices (ex sales), just like Open Prices does.