### PR TITLE
fix: fix INVALID_ARGUMENT when calling Gemini

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1011,14 +1011,14 @@ requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
 
 [[package]]
 name = "google-genai"
-version = "1.26.0"
+version = "1.29.0"
 description = "GenAI Python SDK"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "google_genai-1.26.0-py3-none-any.whl", hash = "sha256:a050de052ee6e68654ba7cdb97028a576ad7108d0ecc9257c69bcc555498e9a2"},
-    {file = "google_genai-1.26.0.tar.gz", hash = "sha256:d7b019ac98ca07888caa6121a953eb65db20f78370d8ae06aec29fb534534dc8"},
+    {file = "google_genai-1.29.0-py3-none-any.whl", hash = "sha256:8b64737de008d15ca4737e593913f88f656f0568544ab6901f768f0d1fd69bbf"},
+    {file = "google_genai-1.29.0.tar.gz", hash = "sha256:a6b036ab032830f668d137b198c2a5abd8951a036d7a8480b61ce837c1c7f36b"},
 ]
 
 [package.dependencies]
@@ -1027,7 +1027,7 @@ google-auth = ">=2.14.1,<3.0.0"
 httpx = ">=0.28.1,<1.0.0"
 pydantic = ">=2.0.0,<3.0.0"
 requests = ">=2.28.1,<3.0.0"
-tenacity = ">=8.2.3,<9.0.0"
+tenacity = ">=8.2.3,<9.2.0"
 typing-extensions = ">=4.11.0,<5.0.0"
 websockets = ">=13.0.0,<15.1.0"
 
@@ -4043,4 +4043,4 @@ viz = ["cartopy", "matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.11"
-content-hash = "82b2424fe121ff176b7e9f64da2db557b7d85bb6660d8ff8940d1f1be1b11547"
+content-hash = "1c9f147ea7516802b248df58322c5ec6c233c4c625432d9b6bbbb428bc70c966"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ ipython = "^8.26.0"
 gunicorn = "^22.0.0"
 sentry-sdk = {extras = ["django"], version = "^2.13.0"}
 pillow = "^10.4.0"
-google-genai = "~1.26.0"
+google-genai = "~1.29.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "~23.12.1"


### PR DESCRIPTION
Bumping `google-genai` version make the error disappear.