### PR TITLE
refactor(Proofs): move duplicate queryset to model + test

### DIFF
--- a/open_prices/proofs/management/commands/remove_duplicate_proofs.py
+++ b/open_prices/proofs/management/commands/remove_duplicate_proofs.py
@@ -84,16 +84,7 @@ class Command(BaseCommand):
         self.stdout.write("Number of prices before cleanup: %d" % Price.objects.count())
         self.stdout.write(f"MD5 check enabled: {md5_check}")
 
-        proofs_to_delete = list(
-            Proof.objects.filter(
-                owner=ref_proof.owner,
-                date=ref_proof.date,
-                type=ref_proof.type,
-                location_id=ref_proof.location_id,
-            )
-            .exclude(id=ref_proof.id)
-            .all()
-        )
+        proofs_to_delete = list(Proof.objects.duplicates(ref_proof))
 
         self.stdout.write(
             f"Found {len(proofs_to_delete)} proofs to delete (excluding the reference proof)."

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -87,6 +87,19 @@ class ProofQuerySet(models.QuerySet):
             prices__tags__contains=[challenge.tag]
         )
 
+    def duplicates(self, ref_proof):
+        """
+        Input: a reference proof
+        Output: all proofs that have the same owner, date, type, and location_id  # noqa
+        """
+        return self.filter(
+            type=ref_proof.type,
+            location_id=ref_proof.location_id,
+            date=ref_proof.date,
+            owner=ref_proof.owner,
+        ).exclude(id=ref_proof.id)
+        # TODO: add md5 check
+
 
 class Proof(models.Model):
     FILE_FIELDS = ["file_path", "mimetype", "image_thumb_path"]

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -208,6 +208,65 @@ class ProofChallengeQuerySetAndPropertyTest(TestCase):
         )
 
 
+class ProofDuplicatesQuerySetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        location_osm = LocationFactory()
+        location_online = LocationFactory(type=location_constants.TYPE_ONLINE)
+        cls.proof_1_1 = ProofFactory(
+            type=proof_constants.TYPE_PRICE_TAG,
+            location_id=location_osm.id,
+            location_osm_id=location_osm.osm_id,
+            location_osm_type=location_osm.osm_type,
+            date="2024-01-01",
+            owner="user_1",
+        )
+        cls.proof_1_2 = ProofFactory(
+            type=proof_constants.TYPE_PRICE_TAG,
+            location_id=location_osm.id,
+            location_osm_id=location_osm.osm_id,
+            location_osm_type=location_osm.osm_type,
+            date="2024-01-01",
+            owner="user_1",
+        )
+        ProofFactory(
+            type=proof_constants.TYPE_RECEIPT,  # changed
+            location_id=location_osm.id,
+            location_osm_id=location_osm.osm_id,
+            location_osm_type=location_osm.osm_type,
+            date="2024-01-01",
+            owner="user_1",
+        )
+        ProofFactory(
+            type=proof_constants.TYPE_PRICE_TAG,
+            location_id=location_online.id,  # changed
+            date="2024-01-01",
+            owner="user_1",
+        )
+        ProofFactory(
+            type=proof_constants.TYPE_PRICE_TAG,
+            location_id=location_osm.id,
+            location_osm_id=location_osm.osm_id,
+            location_osm_type=location_osm.osm_type,
+            date="2024-01-02",  # changed
+            owner="user_1",
+        )
+        ProofFactory(
+            type=proof_constants.TYPE_PRICE_TAG,
+            location_id=location_osm.id,
+            location_osm_id=location_osm.osm_id,
+            location_osm_type=location_osm.osm_type,
+            date="2024-01-01",
+            owner="user_2",  # changed
+        )
+
+    def test_duplicates(self):
+        self.assertEqual(Proof.objects.count(), 6)
+        duplicates = Proof.objects.duplicates(self.proof_1_1)
+        self.assertEqual(duplicates.count(), 1)
+        self.assertEqual(duplicates.first().id, self.proof_1_2.id)
+
+
 class ProofModelSaveTest(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
### What

Following #902
Start moving some logic to the `Proof` model