### PR TITLE
ci: remove ref to latest release please hash

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-    "last-release-sha": "bf5849f4ce552d27478146067f4e4bb3c1b7212e",
     "packages": {
         ".": {
             "release-type": "simple"


### PR DESCRIPTION
Following #953

This is no longer needed now that we migrated to v4.3.