### PR TITLE
chore: remove required arguments for makemigrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ cli: guard-args
 	${DOCKER_COMPOSE} run --rm --no-deps api python3 manage.py ${args}
 
 
-makemigrations: guard-args
+makemigrations:
 	${DOCKER_COMPOSE} run --rm --no-deps api python3 manage.py makemigrations ${args}
 
 #---------#


### PR DESCRIPTION
most of the time, we don't provide any arguments to it.