### PR TITLE
fix(API): Make the Bearer token prefix case-insensitive

### DIFF
--- a/open_prices/common/authentication.py
+++ b/open_prices/common/authentication.py
@@ -22,7 +22,7 @@ def get_token_from_header(request: Request) -> str | None:
     Expected format: "Bearer <user_id>__U<uuid>"
     """
     authorization = request.META.get("HTTP_AUTHORIZATION")
-    if authorization and "Bearer " in authorization:
+    if authorization and "bearer " in authorization.lower():
         return authorization.split(" ")[1]
     return None
 

--- a/open_prices/common/tests.py
+++ b/open_prices/common/tests.py
@@ -77,6 +77,12 @@ class AuthenticationTest(TestCase):
             headers={"Authorization": f"Bearer {self.user_session.token}"},
         )
         self.assertEqual(get_token_from_header(request), self.user_session.token)
+        # token is case-insensitive
+        request = APIRequestFactory().get(
+            self.url,
+            headers={"Authorization": f"beAreR {self.user_session.token}"},
+        )
+        self.assertEqual(get_token_from_header(request), self.user_session.token)
 
     def test_has_token_from_cookie_or_header(self):
         # no token


### PR DESCRIPTION
### What

In #969 we did some refactoring on how we read the Bearer token, and involuntarily introduced a case-sensitive check on the word "Bearer".

But the specs allow for flexibility : https://auth0.com/blog/the-bearer-token-case/

This PR fixes this.

Follows a discussion in https://github.com/openfoodfacts/openfoodfacts-dart/issues/1128
