### PR TITLE
fix(Proofs): allow a date of tomorrow to manage users in future time zones

### DIFF
--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -1,3 +1,4 @@
+import datetime
 import decimal
 
 from django.conf import settings
@@ -206,7 +207,8 @@ class Proof(models.Model):
         # dict to store all ValidationErrors
         validation_errors = dict()
         # proof rules
-        # - date should have the right format & not be in the future
+        # - date should have the right format
+        # - not be in the future (we accept 1 day leniency for users in future time zones)  # noqa
         if self.date:
             if type(self.date) is str:
                 validation_errors = utils.add_validation_error(
@@ -214,7 +216,7 @@ class Proof(models.Model):
                     "date",
                     "Parsing error. Expected format: YYYY-MM-DD",
                 )
-            elif self.date > timezone.now().date():
+            elif self.date > timezone.now().date() + datetime.timedelta(days=1):
                 validation_errors = utils.add_validation_error(
                     validation_errors,
                     "date",

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -277,10 +277,15 @@ class ProofModelSaveTest(TestCase):
         pass
 
     def test_proof_date_validation(self):
-        for DATE_OK in [None, "2024-01-01"]:
+        for DATE_OK in [None, "2024-01-01", "20240101", "2024-1-1", "1000-01-01"]:
             ProofFactory(date=DATE_OK)
         for DATE_NOT_OK in ["3000-01-01", "01-01-2000"]:
-            self.assertRaises(ValidationError, ProofFactory, date=DATE_NOT_OK)
+            with self.subTest(DATE_NOT_OK=DATE_NOT_OK):
+                self.assertRaises(ValidationError, ProofFactory, date=DATE_NOT_OK)
+        with freeze_time("2025-01-01"):
+            ProofFactory(date="2025-01-01")  # today
+            ProofFactory(date="2025-01-02")  # tomorrow accepted as well
+            self.assertRaises(ValidationError, ProofFactory, date="2025-01-03")
 
     def test_proof_location_validation(self):
         location_osm = LocationFactory()


### PR DESCRIPTION
### What

Following a issue raised on the mobile repo : https://github.com/openfoodfacts/smooth-app/issues/6855