### PR TITLE
chore(Proofs): add a CLI command to compute the MD5 hash of image files

### DIFF
--- a/open_prices/proofs/management/commands/compute_missing_image_hash.py
+++ b/open_prices/proofs/management/commands/compute_missing_image_hash.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+
+from open_prices.proofs.models import Proof
+from open_prices.proofs.utils import compute_file_md5_from_path
+
+
+class Command(BaseCommand):
+    """This command computes the image md5 hash for Proofs that don't have it
+    yet."""
+
+    def handle(self, *args, **options) -> None:  # type: ignore
+        updated = 0
+        for proof in Proof.objects.filter(image_md5_hash__isnull=True):
+            file_path = Path(proof.file_path_full)
+
+            if not file_path.exists():
+                self.stdout.write(f"File does not exist: {file_path}")
+                continue
+
+            updated += 1
+            proof.image_md5_hash = compute_file_md5_from_path(file_path)
+            self.stdout.write(
+                f"Updated proof {proof.id} with MD5 {proof.image_md5_hash}"
+            )
+            proof.save(update_fields=["image_md5_hash"])
+
+        self.stdout.write(f"Updated {updated} proofs.")

--- a/open_prices/proofs/utils.py
+++ b/open_prices/proofs/utils.py
@@ -151,6 +151,28 @@ def compute_file_md5(file: InMemoryUploadedFile | TemporaryUploadedFile) -> str:
     return md5_hash.hexdigest()
 
 
+def compute_file_md5_from_path(file_path: Path) -> str:
+    """Compute the MD5 hash of a file.
+
+    This is the same as `compute_file_md5`, but it takes a file path instead of
+    a Django uploaded file as input.
+
+    :param file_path: the path to the file
+    :return: the MD5 hash of the file as a hexadecimal string
+    """
+
+    md5_hash = hashlib.md5()
+    # Read the file in chunks to avoid using too much memory
+    with file_path.open("rb") as file:
+        while True:
+            chunk = file.read(64 * 2**10)  # 64KB, just as Django's default chunk size
+            if not chunk:
+                break
+            md5_hash.update(chunk)
+
+    return md5_hash.hexdigest()
+
+
 def select_proof_image_dir(images_dir: Path, max_images_per_dir: int = 1_000) -> Path:
     """ "Select the directory where to store the image.
 


### PR DESCRIPTION
For proofs for which this field is null.

Linked to #514

Following the addition of the field in #964