### PR TITLE
chore: update the remove_duplicate_proofs.py script

### DIFF
--- a/open_prices/proofs/management/commands/remove_duplicate_proofs.py
+++ b/open_prices/proofs/management/commands/remove_duplicate_proofs.py
@@ -1,41 +1,27 @@
 import argparse
-import hashlib
 
 from django.core.management.base import BaseCommand
+from django.db.models import Count
 
 from open_prices.prices.models import Price
 from open_prices.proofs.models import Proof
 
 
-def compute_image_md5(file_path: str) -> str:
-    """Compute the MD5 hash of an image file."""
-    hasher = hashlib.md5()
-    with open(file_path, "rb") as f:
-        while chunk := f.read(8192):
-            hasher.update(chunk)
-    return hasher.hexdigest()
-
-
 class Command(BaseCommand):
-    """Remove duplicated proofs, based on the provided filters.
+    """Remove duplicated proofs.
 
-    This script removes proofs that have the same owner, date,
-    type and location as the provided proof: only the reference proof
-    of the group is kept.
+    This script removes proofs that have the same owner, date, type and
+    location and image MD5 hash: only the first uploaded proof of the group
+    (named reference proof) is kept.
 
     All prices associated with these proofs are also updated to point to the
     reference proof.
 
     It is useful to clean up the database from duplicate proofs that may have
     been created by mistake.
-
-    By default, it checks the MD5 hash of the images to ensure that only
-    identical images are considered duplicates. If you want to remove
-    duplicates based on metadata only (owner, date, type, location), you
-    can disable the MD5 check with the `--no-md5-check` option.
     """
 
-    help = "Remove duplicated proofs, based on a reference proof."
+    help = "Remove duplicated proofs."
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -44,64 +30,62 @@ class Command(BaseCommand):
             help="Run the cleanup and apply changes, otherwise just show what would be done (dry run).",
             default=False,
         )
-        parser.add_argument(
-            "--proof-id",
-            help="ID of the reference proof.",
-            type=int,
-            required=True,
-        )
-        parser.add_argument(
-            "--no-md5-check",
-            action="store_false",
-            help="Disable MD5 check between images. "
-            "This is useful if you want to remove duplicates based on metadata only, "
-            "without checking if the images are actually identical.",
-            dest="md5_check",
-            default=True,
-        )
 
     def handle(self, *args, **options) -> None:  # type: ignore
         apply = options["apply"]
-        proof_id = options["proof_id"]
-        md5_check = options["md5_check"]
 
-        ref_proof = Proof.objects.get(pk=proof_id)
-        self.stdout.write("=== Running script to remove duplicate proofs...")
-        self.stdout.write(
-            f"Owner: {ref_proof.owner}, Date: {ref_proof.date}, "
-            f"ref proof ID: {ref_proof.id}, Type: {ref_proof.type}, Location ID: "
-            f"{ref_proof.location_id}"
+        # Fetch all proofs for which at least one other proof has the same
+        # owner, date, type, location and image MD5 hash.
+        # First, group by these fields and count the number of proofs in each
+        # group. Then, filter groups with more than one proof (i.e.
+        # duplicates), and ignore proofs with null image MD5 hash.
+        proof_groups = (
+            Proof.objects.values(
+                "owner",
+                "date",
+                "type",
+                "location_id",
+                "image_md5_hash",
+            )
+            .annotate(proof_count=Count("*"))
+            .filter(proof_count__gt=1)
+            .filter(image_md5_hash__isnull=False)
         )
-        if not apply:
-            self.stdout.write("Running in dry run mode. Use --apply to apply changes.")
+        moved_price_count = 0
+        deleted_proof_count = 0
+        for proof_group in proof_groups:
+            # Fetch all proofs in this group
+            # Order by ID to keep the first uploaded proof as reference proof
+            proofs = list(
+                Proof.objects.filter(
+                    owner=proof_group["owner"],
+                    date=proof_group["date"],
+                    type=proof_group["type"],
+                    location_id=proof_group["location_id"],
+                    image_md5_hash=proof_group["image_md5_hash"],
+                ).order_by("id")
+            )
+            moved_price_count_, deleted_proof_count_ = self.remove_duplicates(
+                proofs=proofs, apply=apply
+            )
+            moved_price_count += moved_price_count_
+            deleted_proof_count += deleted_proof_count_
 
-        self.remove_duplicates(ref_proof=ref_proof, apply=apply, md5_check=md5_check)
+        self.stdout.write(
+            f"Total moved prices: {moved_price_count}, total deleted proofs: {deleted_proof_count}."
+        )
 
     def remove_duplicates(
-        self, ref_proof: Proof, apply: bool = False, md5_check: bool = True
-    ) -> None:
-        self.stdout.write("Number of proofs before cleanup: %d" % Proof.objects.count())
-        self.stdout.write("Number of prices before cleanup: %d" % Price.objects.count())
-        self.stdout.write(f"MD5 check enabled: {md5_check}")
+        self, proofs: list[Proof], apply: bool = False
+    ) -> tuple[int, int]:
+        if len(proofs) < 2:
+            raise ValueError("At least two proofs are required to remove duplicates.")
 
-        proofs_to_delete = list(Proof.objects.duplicates(ref_proof))
-
+        ref_proof = proofs[0]  # Keep the first proof as reference
+        proofs_to_delete = proofs[1:]  # The rest will be deleted
         self.stdout.write(
-            f"Found {len(proofs_to_delete)} proofs to delete (excluding the reference proof)."
+            f"Found {len(proofs_to_delete)} proofs to delete (excluding the reference proof, ID: {ref_proof.id})."
         )
-
-        if md5_check:
-            # Filter proofs based on MD5 hash of the image
-            ref_image_md5 = compute_image_md5(ref_proof.file_path_full)
-            proofs_to_delete = [
-                proof
-                for proof in proofs_to_delete
-                if compute_image_md5(proof.file_path_full) == ref_image_md5
-            ]
-
-            self.stdout.write(
-                f"After MD5 check, {len(proofs_to_delete)} proofs remain to be deleted."
-            )
 
         prices_to_move = Price.objects.filter(proof__in=proofs_to_delete).all()
 
@@ -123,12 +107,9 @@ class Command(BaseCommand):
             for price in prices_to_move:
                 price.proof = ref_proof
                 price.save()
-            self.stdout.write("Updated prices: %d." % prices_to_move.count())
 
             # Now delete the proofs
             for proof in proofs_to_delete:
                 proof.delete()
-            self.stdout.write("Deleted %d proofs." % len(proofs_to_delete))
 
-        self.stdout.write("Number of proofs after cleanup: %d" % Proof.objects.count())
-        self.stdout.write("Number of prices after cleanup: %d" % Price.objects.count())
+        return len(prices_to_move), len(proofs_to_delete)

--- a/open_prices/proofs/management/commands/remove_duplicate_proofs.py
+++ b/open_prices/proofs/management/commands/remove_duplicate_proofs.py
@@ -65,11 +65,11 @@ class Command(BaseCommand):
                     image_md5_hash=proof_group["image_md5_hash"],
                 ).order_by("id")
             )
-            moved_price_count_, deleted_proof_count_ = self.remove_duplicates(
+            group_moved_price_count, group_deleted_proof_count = self.remove_duplicates(
                 proofs=proofs, apply=apply
             )
-            moved_price_count += moved_price_count_
-            deleted_proof_count += deleted_proof_count_
+            moved_price_count += group_moved_price_count
+            deleted_proof_count += group_deleted_proof_count
 
         self.stdout.write(
             f"Total moved prices: {moved_price_count}, total deleted proofs: {deleted_proof_count}."


### PR DESCRIPTION
It now uses the new `image_md5_hash` field to find all group of proofs that have the same, date, owner, location_id and image_md5_hash.