### PR TITLE
fix: return "status": "duplicate" when a duplicate proof is uploaded

### DIFF
--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -379,6 +379,7 @@ class ProofCreateApiTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["id"], proof_id)
+        self.assertEqual(response.data.get("status"), "duplicate")
 
         # Different date => create a new proof
         response = self.client.post(

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -193,7 +193,7 @@ class ProofViewSet(
                 status_code = status.HTTP_201_CREATED
 
             return Response(
-                ProofFullSerializer(duplicate_proof).data,
+                {**ProofFullSerializer(duplicate_proof).data, "status": "duplicate"},
                 status=status_code,
             )
 


### PR DESCRIPTION
This was part of the original issue
https://github.com/openfoodfacts/open-prices/issues/514#issuecomment-3184397560 but was not implemented.