### PR TITLE
feat: implement a barcode similarity search feature for price tags

### DIFF
--- a/open_prices/common/db_func.py
+++ b/open_prices/common/db_func.py
@@ -1,0 +1,34 @@
+from django.db.models import Func
+
+
+class LevenshteinLessEqual(Func):
+    """Django implementation of the Levenshtein distance function with a
+    maximum distance (lenvenshtein_less_equal), brought by the fuzzystrmatch
+    extension.
+
+    See
+    https://www.postgresql.org/docs/current/fuzzystrmatch.html#FUZZYSTRMATCH-LEVENSHTEIN.
+    """
+
+    template = "%(function)s(%(source)s, '%(target)s', %(ins_cost)d, %(del_cost)d, %(sub_cost)d, %(max_d)d)"
+    function = "levenshtein_less_equal"
+
+    def __init__(
+        self,
+        source: str,
+        target: str,
+        max_d: int,
+        ins_cost=1,
+        del_cost=1,
+        sub_cost=1,
+        **extras
+    ):
+        super().__init__(
+            source=source,
+            target=target,
+            ins_cost=ins_cost,
+            del_cost=del_cost,
+            sub_cost=sub_cost,
+            max_d=max_d,
+            **extras
+        )

--- a/open_prices/products/migrations/0007_add_fuzzystrmatch_extension.py
+++ b/open_prices/products/migrations/0007_add_fuzzystrmatch_extension.py
@@ -1,0 +1,12 @@
+# Generated manually on 2025-09-22 15:22
+
+from django.contrib.postgres.operations import CreateExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("products", "0006_alter_product_source"),
+    ]
+
+    operations = [CreateExtension("fuzzystrmatch")]

--- a/open_prices/products/models.py
+++ b/open_prices/products/models.py
@@ -8,6 +8,7 @@ from django_q.tasks import async_task
 
 # Import custom lookups so that they are registered
 from open_prices.common import lookups  # noqa: F401
+from open_prices.common.db_func import LevenshteinLessEqual
 from open_prices.products import constants as product_constants
 
 
@@ -162,6 +163,41 @@ class Product(models.Model):
             .count()
         )
         self.save(update_fields=["proof_count"])
+
+    @classmethod
+    def fuzzy_barcode_search(
+        cls, code: str, max_distance: int = 3, limit: int | None = None
+    ) -> models.QuerySet:
+        """Use the `levenshtein_less_equal` from the fuzzystrmatch extension
+        to find Products with barcode that are similar to the given barcode.
+
+        Results are ordered by increasing Levenshtein distance.
+
+        :param code: The barcode to search for
+        :param max_distance: The maximum Levenshtein distance to consider
+        :param limit: The maximum number of results to return, or None for no
+            limit
+        :return: A queryset of Product with similar barcodes
+        """
+
+        # Easy way to prevent SQL injection and useless queries
+        if not code.isdigit():
+            return cls.objects.none()
+
+        qs = (
+            Product.objects.annotate(
+                distance=LevenshteinLessEqual(
+                    "code", code, max_distance, output_field=models.IntegerField()
+                ),
+            )
+            .filter(distance__lte=max_distance)
+            .order_by("distance")
+        )
+
+        if limit:
+            qs = qs[:limit]
+
+        return qs
 
 
 @receiver(signals.post_save, sender=Product)

--- a/open_prices/products/tests.py
+++ b/open_prices/products/tests.py
@@ -294,3 +294,40 @@ class TestProcessUpdate(TestCase):
         self.assertEqual(create_product.source, Flavor.opff)
         self.assertGreater(create_product.source_last_synced, before)
         self.assertLess(create_product.source_last_synced, after)
+
+
+class TestProductModel(TestCase):
+    def test_fuzzy_barcode_search(self):
+        ProductFactory(code="0123456789100")
+        ProductFactory(code="0123456789101")
+        ProductFactory(code="0123456789102")
+        ProductFactory(code="0123456789103")
+        ProductFactory(code="1123456789100")
+        ProductFactory(code="1123456789101")
+        ProductFactory(code="1123456789102")
+        ProductFactory(code="1123456789103")
+        ProductFactory(code="2123456789100")
+        ProductFactory(code="2123456789101")
+        ProductFactory(code="2123456789102")
+        ProductFactory(code="2123456789103")
+
+        results = list(Product.fuzzy_barcode_search("0123456789100", max_distance=0))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].code, "0123456789100")
+
+        results = list(Product.fuzzy_barcode_search("0123456789100", max_distance=1))
+        self.assertEqual(len(results), 6)
+        self.assertEqual(
+            set(p.code for p in results),
+            {
+                "0123456789100",
+                "0123456789101",
+                "0123456789102",
+                "0123456789103",
+                "1123456789100",
+                "2123456789100",
+            },
+        )
+
+        results = list(Product.fuzzy_barcode_search("0123456789100", max_distance=2))
+        self.assertEqual(len(results), 12)

--- a/open_prices/products/tests.py
+++ b/open_prices/products/tests.py
@@ -311,11 +311,15 @@ class TestProductModel(TestCase):
         ProductFactory(code="2123456789102")
         ProductFactory(code="2123456789103")
 
-        results = list(Product.fuzzy_barcode_search("0123456789100", max_distance=0))
+        results = list(
+            Product.objects.fuzzy_barcode_search("0123456789100", max_distance=0)
+        )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].code, "0123456789100")
 
-        results = list(Product.fuzzy_barcode_search("0123456789100", max_distance=1))
+        results = list(
+            Product.objects.fuzzy_barcode_search("0123456789100", max_distance=1)
+        )
         self.assertEqual(len(results), 6)
         self.assertEqual(
             set(p.code for p in results),
@@ -329,5 +333,7 @@ class TestProductModel(TestCase):
             },
         )
 
-        results = list(Product.fuzzy_barcode_search("0123456789100", max_distance=2))
+        results = list(
+            Product.objects.fuzzy_barcode_search("0123456789100", max_distance=2)
+        )
         self.assertEqual(len(results), 12)

--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -885,7 +885,7 @@ def run_and_save_price_tag_extraction(
         if barcode and not Product.objects.filter(code=barcode).exists():
             similar_barcodes = [
                 BarcodeSimilarityMatch(barcode=p.code, distance=p.distance)
-                for p in Product.fuzzy_barcode_search(
+                for p in Product.objects.fuzzy_barcode_search(
                     barcode,
                     # Only return products with a levenshtein distance of 3 or
                     # less


### PR DESCRIPTION
Using levenshtein distance, we search for the similar barcodes (with a distance <= 3) so that we can suggest products based on the (wrongly) extracted barcode. Luckily, we can leverage a PostgreSQL native extension (https://www.postgresql.org/docs/current/fuzzystrmatch.html#FUZZYSTRMATCH-LEVENSHTEIN) to perform efficiently fuzzy search on barcode, using the `products` table. 

We save the result in `data.similar_barcodes` field of the `PriceTagPrediction`:

`[{"distance": 2, "barcode": "5252525"}]`

`distance` is the levenhstein distance with the extracted barcode and `barcode` is the match.
We don't include in the list the original barcode (distance=0). There is at most 10 items in this list.

The front-end needs to be updated to leverage this new field.

I performed a few tests (~15) using price tags from the validation assistant in prod for which the extracted barcode was invalid.
The results were very good: there were only 2 price tags (out of 15) for which I couldn't find the result in the top 10.

As a shortcoming for this test, this was French products (for which we have a very good product coverage).