### PR TITLE
feat(Products): New API endpoints to update/add Product Opener products and images

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -24,6 +24,7 @@ ALLOWED_HOSTS = [x.strip() for x in os.getenv("ALLOWED_HOSTS", "").split(",")]
 # front-end is using Vue.js and Django REST Framework
 CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",")
 
+
 # App config
 # ------------------------------------------------------------------------------
 
@@ -310,6 +311,9 @@ SESSION_COOKIE_NAME = "opsession"
 OFF_USER_AGENT = "open-prices/0.1.0"
 
 OFF_ENVIRONMENT = os.getenv("OFF_ENVIRONMENT", "net")  # or "org"
+
+OFF_DEFAULT_USER = os.getenv("OFF_DEFAULT_USER", "open-prices")
+OFF_DEFAULT_PASSWORD = os.getenv("OFF_DEFAULT_PASSWORD")
 
 # https://world.openfoodfacts.org/contributor/openfoodfacts-contributors
 ANONYMOUS_USER_ID = "openfoodfacts-contributors"

--- a/open_prices/api/products/tests.py
+++ b/open_prices/api/products/tests.py
@@ -167,7 +167,7 @@ class ProductCreateApiTest(TestCase):
         response = self.client.post(
             self.url, self.data, content_type="application/json"
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)  # 405 ?
         # authenticated
         response = self.client.post(
             self.url,
@@ -191,7 +191,7 @@ class ProductUpdateApiTest(TestCase):
         response = self.client.patch(
             self.url, self.data, content_type="application/json"
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)  # 405 ?
         # authenticated
         response = self.client.patch(
             self.url,
@@ -212,9 +212,53 @@ class ProductDeleteApiTest(TestCase):
     def test_product_delete_not_allowed(self):
         # anonymous
         response = self.client.delete(self.url)
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, 403)  # 405 ?
         # authenticated
         response = self.client.delete(
             self.url, headers={"Authorization": f"Bearer {self.user_session.token}"}
         )
         self.assertEqual(response.status_code, 405)
+
+
+class ProductOffCreateOrUpdateApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_session = SessionFactory()
+        cls.product = ProductFactory(**PRODUCT_8001505005707)
+        cls.url = reverse(
+            "api:products-create-or-update-in-off", args=[cls.product.code]
+        )
+
+    def test_product_off_create_or_update(self):
+        # anonymous
+        response = self.client.post(self.url, {}, content_type="application/json")
+        self.assertEqual(response.status_code, 403)
+        # authenticated
+        # response = self.client.post(
+        #     self.url,
+        #     {},
+        #     headers={"Authorization": f"Bearer {self.user_session.token}"},
+        #     content_type="application/json",
+        # )
+        # self.assertEqual(response.status_code, 200)
+
+
+class ProductOffUploadImageApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_session = SessionFactory()
+        cls.product = ProductFactory(**PRODUCT_8001505005707)
+        cls.url = reverse("api:products-upload-image-in-off", args=[cls.product.code])
+
+    def test_product_off_upload_image(self):
+        # anonymous
+        response = self.client.post(self.url, {}, content_type="application/json")
+        self.assertEqual(response.status_code, 403)
+        # authenticated
+        # response = self.client.post(
+        #     self.url,
+        #     {},
+        #     headers={"Authorization": f"Bearer {self.user_session.token}"},
+        #     content_type="application/json",
+        # )
+        # self.assertEqual(response.status_code, 200)

--- a/open_prices/api/products/views.py
+++ b/open_prices/api/products/views.py
@@ -7,6 +7,10 @@ from rest_framework.response import Response
 from open_prices.api.products.filters import ProductFilter
 from open_prices.api.products.serializers import ProductFullSerializer
 from open_prices.api.utils import get_object_or_drf_404
+from open_prices.common.openfoodfacts import (
+    update_off_product,
+    update_off_product_image,
+)
 from open_prices.products.models import Product
 
 
@@ -27,3 +31,31 @@ class ProductViewSet(
         product = get_object_or_drf_404(Product, code=code)
         serializer = self.get_serializer(product)
         return Response(serializer.data)
+
+    @action(
+        detail=False, methods=["PATCH", "POST"], url_path=r"off_update/(?P<code>.+)"
+    )
+    def update_off_product(self, request: Request, code):
+        result = update_off_product(
+            code,
+            flavor=request.data.get("flavor", "off"),
+            update_params=request.data.get("update_params"),
+        )
+        if result:
+            return Response(result, status=200)
+        return Response(status=400)
+
+    @action(
+        detail=False,
+        methods=["PATCH", "POST"],
+        url_path=r"off_update_image/(?P<code>.+)",
+    )
+    def update_off_product_image(self, request: Request, code):
+        result = update_off_product_image(
+            code,
+            flavor=request.data.get("flavor", "off"),
+            image_src=request.data.get("image_src"),
+        )
+        if result:
+            return Response(result, status=200)
+        return Response(status=400)

--- a/open_prices/api/products/views.py
+++ b/open_prices/api/products/views.py
@@ -1,6 +1,8 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from openfoodfacts import Flavor
 from rest_framework import filters, mixins, viewsets
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -9,8 +11,8 @@ from open_prices.api.products.serializers import ProductFullSerializer
 from open_prices.api.utils import get_object_or_drf_404
 from open_prices.common.authentication import CustomAuthentication
 from open_prices.common.openfoodfacts import (
-    update_off_product,
-    update_off_product_image,
+    create_or_update_product_in_off,
+    upload_product_image_in_off,
 )
 from open_prices.products.models import Product
 
@@ -19,6 +21,7 @@ class ProductViewSet(
     mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
 ):
     authentication_classes = []  # see get_authenticators
+    permission_classes = [IsAuthenticatedOrReadOnly]
     queryset = Product.objects.all()
     serializer_class = ProductFullSerializer
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
@@ -40,18 +43,16 @@ class ProductViewSet(
         return Response(serializer.data)
 
     @action(
-        detail=False, methods=["PATCH", "POST"], url_path=r"off_update/(?P<code>.+)"
+        detail=False,
+        methods=["POST", "PATCH"],
+        url_path=r"code/(?P<code>\d+)/off-update",
     )
-    def update_off_product(self, request: Request, code):
-        if self.request.user.is_authenticated:
-            owner = self.request.user.user_id
-        else:
-            owner = None
-        result = update_off_product(
+    def create_or_update_in_off(self, request: Request, code):
+        result = create_or_update_product_in_off(
             code,
-            flavor=request.data.get("flavor", "off"),
-            owner=owner,
-            update_params=request.data.get("update_params"),
+            flavor=request.data.get("flavor", Flavor.off),
+            owner=self.request.user.user_id,
+            update_params=request.data.get("update_params", {}),
         )
         if result:
             return Response(result, status=200)
@@ -59,13 +60,13 @@ class ProductViewSet(
 
     @action(
         detail=False,
-        methods=["PATCH", "POST"],
-        url_path=r"off_update_image/(?P<code>.+)",
+        methods=["POST", "PATCH"],
+        url_path=r"code/(?P<code>\d+)/off-upload-image",
     )
-    def update_off_product_image(self, request: Request, code):
-        result = update_off_product_image(
+    def upload_image_in_off(self, request: Request, code):
+        result = upload_product_image_in_off(
             code,
-            flavor=request.data.get("flavor", "off"),
+            flavor=request.data.get("flavor", Flavor.off),
             image_data_base64=request.data.get("image_data_base64"),
         )
         if result:

--- a/open_prices/api/products/views.py
+++ b/open_prices/api/products/views.py
@@ -54,7 +54,7 @@ class ProductViewSet(
         result = update_off_product_image(
             code,
             flavor=request.data.get("flavor", "off"),
-            image_src=request.data.get("image_src"),
+            image_data_base64=request.data.get("image_data_base64"),
         )
         if result:
             return Response(result, status=200)

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -310,13 +310,13 @@ def barcode_fix_short_codes_from_usa(barcode: str) -> str:
     return barcode
 
 
-def update_off_product(
-    code: str, flavor: str = "off", owner: str = None, update_params: dict = {}
+def create_or_update_product_in_off(
+    code: str, flavor: str = Flavor.off, owner: str = None, update_params: dict = {}
 ) -> JSONType | None:
     client = API(
-        user_agent=settings.OFF_USER_AGENT,
         username=settings.OFF_DEFAULT_USER,
         password=settings.OFF_DEFAULT_PASSWORD,
+        user_agent=settings.OFF_USER_AGENT,
         country=Country.world,
         flavor=flavor,
         version=APIVersion.v2,
@@ -329,9 +329,9 @@ def update_off_product(
     return client.product.update({"code": code, "comment": comment, **update_params})
 
 
-def update_off_product_image(
+def upload_product_image_in_off(
     code: str,
-    flavor: str = "off",
+    flavor: str = Flavor.off,
     image_data_base64: str = None,
     selected: JSONType | None = None,
 ) -> JSONType | None:

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -1,4 +1,6 @@
+import base64
 import datetime
+import io
 
 import openfoodfacts
 import requests
@@ -17,6 +19,7 @@ from openfoodfacts import (
 )
 from openfoodfacts.images import generate_image_url
 from openfoodfacts.types import JSONType
+from openfoodfacts.utils import URLBuilder
 
 OFF_CREATE_FIELDS = [
     "product_name",
@@ -308,3 +311,41 @@ def barcode_fix_short_codes_from_usa(barcode: str) -> str:
         if barcode_is_valid(barcode_temp):
             return barcode_temp
     return barcode
+
+
+def update_off_product(
+    code: str, flavor: str = "off", update_params: dict = {}
+) -> JSONType | None:
+    client = API(
+        user_agent=settings.OFF_USER_AGENT,
+        username=settings.OFF_DEFAULT_USER,
+        password=settings.OFF_DEFAULT_PASSWORD,
+        country=Country.world,
+        flavor=flavor,
+        version=APIVersion.v2,
+        environment=Environment[os.getenv("ENVIRONMENT")],
+    )
+    return client.product.update({"code": code, **update_params})
+
+
+def update_off_product_image(
+    code: str, flavor: str = "off", image_src: str = None, image_field: str = "front"
+) -> JSONType | None:
+    imgdata = base64.b64decode(image_src.split(",")[1])
+    image_fp = io.BytesIO(imgdata)
+
+    base_url = URLBuilder.world(Flavor(flavor), Environment[os.getenv("ENVIRONMENT")])
+    url = f"{base_url}/cgi/product_image_upload.pl"
+
+    form_data = {}
+
+    form_data["user_id"] = (None, settings.OFF_DEFAULT_USER)
+    form_data["password"] = (None, settings.OFF_DEFAULT_PASSWORD)
+    form_data["code"] = (None, code)
+    form_data["imagefield"] = (None, image_field)
+    form_data[f"imgupload_{image_field}"] = ("image.png", image_fp)
+
+    return requests.post(
+        url,
+        files=form_data,
+    )

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -311,7 +311,7 @@ def barcode_fix_short_codes_from_usa(barcode: str) -> str:
 
 
 def update_off_product(
-    code: str, flavor: str = "off", update_params: dict = {}
+    code: str, flavor: str = "off", owner: str = None, update_params: dict = {}
 ) -> JSONType | None:
     client = API(
         user_agent=settings.OFF_USER_AGENT,
@@ -322,7 +322,11 @@ def update_off_product(
         version=APIVersion.v2,
         environment=Environment[settings.OFF_ENVIRONMENT],
     )
-    return client.product.update({"code": code, **update_params})
+    if owner:
+        comment = f"[Open Prices, user: {owner}]"
+    else:
+        comment = "[Open Prices]"
+    return client.product.update({"code": code, "comment": comment, **update_params})
 
 
 def update_off_product_image(


### PR DESCRIPTION
### What

- Backend part of PR https://github.com/openfoodfacts/open-prices-frontend/pull/1685 allowing Product Opener products addition from Open Prices
- Uses two new settings: OFF_DEFAULT_USER & OFF_DEFAULT_PASSWORD, that should contain username and password of a "default" Open Prices user

- The PR also uses two recently-added filters:
   - `source_isnull` on products, to find products added to the prices' database, but not existing on any Product Opener database : https://github.com/openfoodfacts/open-prices/issues/1030
   - `price_id` on proofs, in order to fetch the proof containing a specific price : https://github.com/openfoodfacts/open-prices/issues/1033

