### PR TITLE
fix(API): Prices: order by ID by default instead of created

### DIFF
--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -34,8 +34,8 @@ class PriceViewSet(
     serializer_class = PriceFullSerializer  # see get_serializer_class
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filterset_class = PriceFilter
-    ordering_fields = ["price", "date", "created"]
-    ordering = ["created"]
+    ordering_fields = ["id", "price", "date", "created"]
+    ordering = ["id"]
 
     def get_authenticators(self):
         if self.request and self.request.method in ["GET"]:


### PR DESCRIPTION
### What

Similar to #947 & #1014
Relieve a bit the load on the API/DB by replacing the default Price API sort from `created` to `id`

Long term solution: add indexes (#949)