### PR TITLE
refactor(Prices): History: add change_reason messages for context

### DIFF
--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -15,6 +15,7 @@ from openfoodfacts.taxonomy import (
     map_to_canonical_id,
 )
 from simple_history.models import HistoricalRecords
+from simple_history.utils import update_change_reason
 
 from open_prices.challenges.models import Challenge
 
@@ -623,6 +624,7 @@ class Price(models.Model):
         # save
         if changes:
             self.save(update_fields=["tags"])
+            update_change_reason(self, "Price.update_tags() method")
 
     def has_category_tag(self, category_tag_list: list):
         if (

--- a/open_prices/proofs/management/commands/remove_duplicate_proofs.py
+++ b/open_prices/proofs/management/commands/remove_duplicate_proofs.py
@@ -2,6 +2,7 @@ import argparse
 
 from django.core.management.base import BaseCommand
 from django.db.models import Count
+from simple_history.utils import update_change_reason
 
 from open_prices.prices.models import Price
 from open_prices.proofs.models import Proof
@@ -107,6 +108,7 @@ class Command(BaseCommand):
             for price in prices_to_move:
                 price.proof = ref_proof
                 price.save()
+                update_change_reason(price, "remove_duplicate_proofs command")
 
             # Now delete the proofs
             for proof in proofs_to_delete:

--- a/open_prices/proofs/management/commands/set_price_product_name_from_proof_predictions.py
+++ b/open_prices/proofs/management/commands/set_price_product_name_from_proof_predictions.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from simple_history.utils import update_change_reason
 
 from open_prices.prices.models import Price
 from open_prices.proofs.models import PriceTag, ReceiptItem
@@ -43,6 +44,10 @@ class Command(BaseCommand):
             if price_tag.get_predicted_product_name():
                 price_tag.price.product_name = price_tag.get_predicted_product_name()
                 price_tag.price.save(update_fields=["product_name"])
+                update_change_reason(
+                    price_tag.price,
+                    "set_price_product_name_from_proof_predictions command",
+                )
 
         # Step 2: ReceiptItem
         self.stdout.write("=== Running script on ReceiptItems...")
@@ -52,6 +57,10 @@ class Command(BaseCommand):
                     receipt_item.get_predicted_product_name()
                 )
                 receipt_item.price.save(update_fields=["product_name"])
+                update_change_reason(
+                    receipt_item.price,
+                    "set_price_product_name_from_proof_predictions command",
+                )
 
         self.stdout.write("=== Stats after ===")
         stats()

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -10,6 +10,7 @@ from django.db.models import Case, Count, F, Q, Value, When, signals
 from django.dispatch import receiver
 from django.utils import timezone
 from django_q.tasks import async_task
+from simple_history.utils import update_change_reason
 
 from open_prices.challenges.models import Challenge
 
@@ -466,6 +467,7 @@ def proof_post_save_update_prices(sender, instance, created, **kwargs):
                 for field in Price.DUPLICATE_PROOF_FIELDS:
                     setattr(price, field, getattr(instance, field))
                     price.save()
+                    update_change_reason(price, "proof_post_save_update_prices signal")
 
 
 @receiver(signals.post_delete, sender=Proof)


### PR DESCRIPTION
### What

There's a couple of places where we update price objects in the code/scripts.
Add a change_reason message.

https://django-simple-history.readthedocs.io/en/latest/historical_model.html#change-reason