### PR TITLE
fix(API): Locations: order by ID by default instead of created

### DIFF
--- a/open_prices/api/locations/views.py
+++ b/open_prices/api/locations/views.py
@@ -25,8 +25,8 @@ class LocationViewSet(
     serializer_class = LocationSerializer
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filterset_class = LocationFilter
-    ordering_fields = Location.COUNT_FIELDS + ["created"]
-    ordering = ["created"]
+    ordering_fields = ["id", "created"] + Location.COUNT_FIELDS
+    ordering = ["id"]
 
     def get_serializer_class(self):
         if self.request.method == "POST":


### PR DESCRIPTION
### What

Similar to #947 & #1014 & #1015
Relieve a bit the load on the API/DB by replacing the default Location API sort from `created` to `id`

Long term solution: add indexes (#949)