### PR TITLE
fix(Price Tags): fix bug introduced by a small refactoring in the barcode similarity queryset

### DIFF
--- a/open_prices/products/models.py
+++ b/open_prices/products/models.py
@@ -20,7 +20,11 @@ class ProductQuerySet(models.QuerySet):
         return self.annotate(price_count_annotated=Count("prices", distinct=True))
 
     def fuzzy_barcode_search(
-        self, code: str, max_distance: int = 3, limit: int | None = None
+        self,
+        code: str,
+        max_distance: int = 3,
+        limit: int | None = None,
+        exclude_distance_0: bool = True,
     ):
         """Use the `levenshtein_less_equal` from the fuzzystrmatch extension
         to find Products with barcode that are similar to the given barcode.
@@ -47,6 +51,9 @@ class ProductQuerySet(models.QuerySet):
             .filter(distance__lte=max_distance)
             .order_by("distance")
         )
+
+        if exclude_distance_0:
+            qs = qs.exclude(distance=0)
 
         if limit:
             qs = qs[:limit]

--- a/open_prices/products/tests.py
+++ b/open_prices/products/tests.py
@@ -312,13 +312,17 @@ class TestProductModel(TestCase):
         ProductFactory(code="2123456789103")
 
         results = list(
-            Product.objects.fuzzy_barcode_search("0123456789100", max_distance=0)
+            Product.objects.fuzzy_barcode_search(
+                "0123456789100", max_distance=0, exclude_distance_0=False
+            )
         )
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].code, "0123456789100")
 
         results = list(
-            Product.objects.fuzzy_barcode_search("0123456789100", max_distance=1)
+            Product.objects.fuzzy_barcode_search(
+                "0123456789100", max_distance=1, exclude_distance_0=False
+            )
         )
         self.assertEqual(len(results), 6)
         self.assertEqual(
@@ -334,6 +338,15 @@ class TestProductModel(TestCase):
         )
 
         results = list(
-            Product.objects.fuzzy_barcode_search("0123456789100", max_distance=2)
+            Product.objects.fuzzy_barcode_search(
+                "0123456789100", max_distance=2, exclude_distance_0=False
+            )
         )
         self.assertEqual(len(results), 12)
+
+        results = list(
+            Product.objects.fuzzy_barcode_search(
+                "0123456789100", max_distance=3, exclude_distance_0=True
+            )
+        )
+        self.assertEqual(len(results), 11)

--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -900,8 +900,8 @@ def run_and_save_price_tag_extraction(
             # Only return products with a levenshtein distance between 1 and 3
             # Don't return too many results
             similar_barcodes_qs = Product.objects.fuzzy_barcode_search(
-                barcode, max_distance=3, limit=11
-            ).exclude(distance=0)
+                barcode, max_distance=3, limit=10
+            )
             similar_barcodes = [
                 BarcodeSimilarityMatch(barcode=p.code, distance=p.distance)
                 for p in similar_barcodes_qs


### PR DESCRIPTION
### What

Following #1009 

I added a commit - https://github.com/openfoodfacts/open-prices/commit/83fed735678783db58070e0ac9ba3cfc1df8f78e - to a refactor a bit the queryset (and exclude the starting barcode).

But there was an error
```
TypeError: Cannot filter a query once a slice has been taken.
```
