### PR TITLE
fix(settings): rename OFF_ENVIRONEMENT to ENVIRONMENT

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -310,7 +310,7 @@ OAUTH2_SERVER_URL = os.getenv("OAUTH2_SERVER_URL")
 SESSION_COOKIE_NAME = "opsession"
 OFF_USER_AGENT = "open-prices/0.1.0"
 
-OFF_ENVIRONMENT = os.getenv("OFF_ENVIRONMENT", "net")  # or "org"
+ENVIRONMENT = os.getenv("ENVIRONMENT", "net")  # or "org"
 
 OFF_DEFAULT_USER = os.getenv("OFF_DEFAULT_USER", "open-prices")
 OFF_DEFAULT_PASSWORD = os.getenv("OFF_DEFAULT_PASSWORD")

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -97,7 +97,7 @@ def generate_main_image_url(
             code,
             image_id=image_id,
             flavor=flavor,
-            environment=Environment[settings.OFF_ENVIRONMENT],
+            environment=Environment[settings.ENVIRONMENT],
         )
 
     return None
@@ -111,7 +111,7 @@ def get_product(code: str, flavor: Flavor = Flavor.off) -> JSONType | None:
         country=Country.world,
         flavor=flavor,
         version=APIVersion.v2,
-        environment=Environment[settings.OFF_ENVIRONMENT],
+        environment=Environment[settings.ENVIRONMENT],
     )
     return client.product.get(code)
 
@@ -320,7 +320,7 @@ def create_or_update_product_in_off(
         country=Country.world,
         flavor=flavor,
         version=APIVersion.v2,
-        environment=Environment[settings.OFF_ENVIRONMENT],
+        environment=Environment[settings.ENVIRONMENT],
     )
     if owner:
         comment = f"[Open Prices, user: {owner}]"
@@ -342,7 +342,7 @@ def upload_product_image_in_off(
         country=Country.world,
         flavor=flavor,
         version=APIVersion.v3,
-        environment=Environment[settings.OFF_ENVIRONMENT],
+        environment=Environment[settings.ENVIRONMENT],
     )
     return client.product.upload_image(
         code, image_data_base64=image_data_base64, selected=selected


### PR DESCRIPTION
### What

In https://github.com/openfoodfacts/open-prices/commit/89c68994ea2492355e12102a9f3783f9224fa136 we had created a new OFF_ENVIRONMENT setting to allow switching from .net to .org

But there is already a ENVIRONMENT env var that is set during deploy. reuse it
