### PR TITLE
fix(deps): fix Redis import following upgrade of openfoodfacts-python

### DIFF
--- a/open_prices/products/management/commands/run_update_listener.py
+++ b/open_prices/products/management/commands/run_update_listener.py
@@ -3,7 +3,7 @@ import time
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from openfoodfacts import Flavor
-from openfoodfacts.redis import RedisUpdate
+from openfoodfacts.redis import ProductUpdateEvent
 from openfoodfacts.redis import UpdateListener as BaseUpdateListener
 from openfoodfacts.redis import get_redis_client
 from openfoodfacts.utils import get_logger
@@ -14,7 +14,7 @@ logger = get_logger()
 
 
 class UpdateListener(BaseUpdateListener):
-    def process_redis_update(self, redis_update: RedisUpdate):
+    def process_redis_update(self, redis_update: ProductUpdateEvent):
         logger.debug("New update: %s", redis_update)
 
         if redis_update.product_type == "food":


### PR DESCRIPTION
### What

In #1029 we upgrade `openfoodfacts-python` from 2.8 to 3.1

But we went to fast and there were some breaking changes regarding Redis :sweat_smile: 

Fixing it here