### PR TITLE
refactor(Proofs): History: add change_reason messages for context

### DIFF
--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -621,6 +621,7 @@ class Price(models.Model):
         if tag not in self.tags:
             self.tags.append(tag)
             if save:
+                self._change_reason = "Price.set_tag() method"
                 self.save(update_fields=["tags"])
             return True
         return False

--- a/open_prices/proofs/management/commands/compute_missing_image_hash.py
+++ b/open_prices/proofs/management/commands/compute_missing_image_hash.py
@@ -24,6 +24,7 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"Updated proof {proof.id} with MD5 {proof.image_md5_hash}"
             )
+            proof._change_reason = "compute_missing_image_hash command"
             proof.save(update_fields=["image_md5_hash"])
 
         self.stdout.write(f"Updated {updated} proofs.")

--- a/open_prices/proofs/management/commands/remove_duplicate_proofs.py
+++ b/open_prices/proofs/management/commands/remove_duplicate_proofs.py
@@ -111,6 +111,7 @@ class Command(BaseCommand):
 
             # Now delete the proofs
             for proof in proofs_to_delete:
+                proof._change_reason = "remove_duplicate_proofs command"
                 proof.delete()
 
         return len(prices_to_move), len(proofs_to_delete)

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -393,6 +393,7 @@ class Proof(models.Model):
         self.location_osm_id = location_osm_id
         self.location_osm_type = location_osm_type
         self.set_location()
+        self._change_reason = "Proof.update_location() method"
         self.save()
         self.refresh_from_db()
         new_location = self.location
@@ -431,12 +432,14 @@ class Proof(models.Model):
                             proof_prices_field_list,
                         )
         if len(fields_to_update):
+            self._change_reason = "Proof.set_missing_fields_from_prices() method"
             self.save()
 
     def set_tag(self, tag: str, save: bool = True):
         if tag not in self.tags:
             self.tags.append(tag)
             if save:
+                self._change_reason = "Proof.set_tag() method"
                 self.save(update_fields=["tags"])
             return True
         return False


### PR DESCRIPTION
### What

Following #1048 (Proof history), and similar to #1016 (same for Prices)

There's a couple of places where we update proof objects in the code/scripts.
Add a change_reason message.

https://django-simple-history.readthedocs.io/en/latest/historical_model.html#change-reason