### PR TITLE
fix(similar-barcode): remove barcodes with invalid checksum

### DIFF
--- a/open_prices/products/models.py
+++ b/open_prices/products/models.py
@@ -36,6 +36,8 @@ class ProductQuerySet(models.QuerySet):
         :param max_distance: The maximum Levenshtein distance to consider
         :param limit: The maximum number of results to return, or None for no
             limit
+        :param exclude_distance_0: Whether to exclude results with distance 0
+            (i.e. exact matches)
         :return: A queryset of Product with similar barcodes
         """
 

--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -905,6 +905,8 @@ def run_and_save_price_tag_extraction(
             similar_barcodes = [
                 BarcodeSimilarityMatch(barcode=p.code, distance=p.distance)
                 for p in similar_barcodes_qs
+                # Check that barcode is valid (correct check digit)
+                if common_openfoodfacts.barcode_is_valid(p.code)
             ]
         data = LabelWithSimilarBarcodes(
             **dict(response.parsed),


### PR DESCRIPTION
After comment in the following PR:
https://github.com/openfoodfacts/open-prices/pull/1009