### PR TITLE
fix(Proofs): API: fix 500 error if date field missing

### DIFF
--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -172,11 +172,11 @@ class ProofViewSet(
         duplicate_proof = Proof.objects.filter(
             image_md5_hash=image_md5_hash,
             owner=owner,
-            type=serializer.validated_data["type"],
+            type=serializer.validated_data.get("type"),
             # location OSM id/type can be null (for online stores)
             location_osm_id=serializer.validated_data.get("location_osm_id"),
             location_osm_type=serializer.validated_data.get("location_osm_type"),
-            date=serializer.validated_data["date"],
+            date=serializer.validated_data.get("date"),
         ).first()
         if duplicate_proof:
             # We remove the uploaded file as it's a duplicate


### PR DESCRIPTION
### What

In #964 we added "duplicate check" logic in the Proof create API view.

But if the proof didn't have a date or type errors were not well managed.