### PR TITLE
fix(Proofs): Prevent exception if there is any problem with the img thumbnail processing

### DIFF
--- a/open_prices/proofs/utils.py
+++ b/open_prices/proofs/utils.py
@@ -83,28 +83,28 @@ def generate_thumbnail(
     if not mimetype.startswith("image"):
         return None
     file_full_path = generate_full_path(current_dir, file_stem, extension)
-    try:
-        with Image.open(file_full_path) as img:
+    with Image.open(file_full_path) as img:
+        try:
             img_thumb = img.copy()
-            # set any rotation info
-            img_thumb = ImageOps.exif_transpose(img)
-            # transform into a thumbnail
-            img_thumb.thumbnail(thumbnail_size, Image.Resampling.LANCZOS)
-            image_thumb_full_path = generate_full_path(
-                current_dir, f"{file_stem}.{settings.THUMBNAIL_SIZE[0]}", extension
-            )
-            # avoid 'cannot write mode RGBA as JPEG' error
-            if mimetype in ("image/jpeg",) and img_thumb.mode in ("RGBA", "P"):
-                img_thumb = img_thumb.convert("RGB")
-            # save (exif will be stripped)
-            img_thumb.save(image_thumb_full_path)
-            image_thumb_path = generate_relative_path(
-                current_dir_id_str,
-                f"{file_stem}.{settings.THUMBNAIL_SIZE[0]}",
-                extension,
-            )
-    except (OSError, Exception):
-        image_thumb_path = None
+        except OSError:
+            return None
+        # set any rotation info
+        img_thumb = ImageOps.exif_transpose(img)
+        # transform into a thumbnail
+        img_thumb.thumbnail(thumbnail_size, Image.Resampling.LANCZOS)
+        image_thumb_full_path = generate_full_path(
+            current_dir, f"{file_stem}.{settings.THUMBNAIL_SIZE[0]}", extension
+        )
+        # avoid 'cannot write mode RGBA as JPEG' error
+        if mimetype in ("image/jpeg",) and img_thumb.mode in ("RGBA", "P"):
+            img_thumb = img_thumb.convert("RGB")
+        # save (exif will be stripped)
+        img_thumb.save(image_thumb_full_path)
+        return generate_relative_path(
+            current_dir_id_str,
+            f"{file_stem}.{settings.THUMBNAIL_SIZE[0]}",
+            extension,
+        )
 
 
 def store_file(


### PR DESCRIPTION
### What

Prevents exceptions when processing an Image. \
If an error occurs, the function simply returns `None`. This is acceptable since `None` is an explicitly allowed return type according to the type annotation.

### Screenshot

Not applicable

### Fixes bug(s)

#942 

### Part of 

Standalone issue/PR
