### PR TITLE
refactor(Challenges): on create, init stats object

### DIFF
--- a/open_prices/challenges/models.py
+++ b/open_prices/challenges/models.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import ValidationError
 from django.db import models
-from django.db.models import Case, Count, F, Func, Value, When
+from django.db.models import Case, Count, F, Func, Value, When, signals
+from django.dispatch import receiver
 from django.utils import timezone
 
 from open_prices.challenges import constants as challenge_constants
@@ -313,3 +314,9 @@ class Challenge(models.Model):
             "updated": timezone.now().isoformat().replace("+00:00", "Z"),
         }
         self.save(update_fields=["stats"])
+
+
+@receiver(signals.post_save, sender=Challenge)
+def location_post_create_init_stats(sender, instance, created, **kwargs):
+    if created:
+        instance.calculate_stats()

--- a/open_prices/challenges/tests.py
+++ b/open_prices/challenges/tests.py
@@ -84,6 +84,10 @@ class ChallengeModelSaveTest(TestCase):
             end_date="2024-06-30",
         )
 
+    def test_challenge_stats(self):
+        c = ChallengeFactory(is_published=False, start_date=None, end_date=None)
+        self.assertIsNotNone(c.stats)
+
 
 class ChallengeQuerySetTest(TestCase):
     @classmethod
@@ -286,11 +290,10 @@ class ChallengePropertyTest(TestCase):
         self.assertIn("test", self.proof_in_challenge.tags)
 
     def test_calculate_stats(self):
-        self.assertIsNone(self.challenge_ongoing.stats)
+        self.assertEqual(self.challenge_ongoing.stats["price_count"], 0)
         self.challenge_ongoing.set_price_tags()  # we need to set the price tags first
         self.challenge_ongoing.set_proof_tags()  # we need to set the proof tags first
         self.challenge_ongoing.calculate_stats()
-        self.assertIsNotNone(self.challenge_ongoing.stats)
         self.assertEqual(self.challenge_ongoing.stats["price_count"], 3)
         self.assertEqual(self.challenge_ongoing.stats["proof_count"], 1)
         self.assertEqual(self.challenge_ongoing.stats["user_count"], 2)


### PR DESCRIPTION
### What

To avoid having errors on the frontend (empty stat object)
