### PR TITLE
refactor(Products): Create in Product Opener: languages and country support

### DIFF
--- a/open_prices/api/products/views.py
+++ b/open_prices/api/products/views.py
@@ -51,6 +51,7 @@ class ProductViewSet(
         result = create_or_update_product_in_off(
             code,
             flavor=request.data.get("flavor", Flavor.off),
+            country_code=request.data.get("product_language_code", "en"),
             owner=self.request.user.user_id,
             update_params=request.data.get("update_params", {}),
         )
@@ -64,11 +65,13 @@ class ProductViewSet(
         url_path=r"code/(?P<code>\d+)/off-upload-image",
     )
     def upload_image_in_off(self, request: Request, code):
+        product_language_code = request.data.get("product_language_code", "en")
         result = upload_product_image_in_off(
             code,
             flavor=request.data.get("flavor", Flavor.off),
+            country_code=product_language_code,
             image_data_base64=request.data.get("image_data_base64"),
-            selected={"front": {"en": {}}},
+            selected={"front": {product_language_code: {}}},
         )
         if result:
             return Response(result, status=200)


### PR DESCRIPTION
### What
- Adds a new optional field `product_language_code` to `create_or_update_in_off` and `upload_image_in_off` APIs
   - This field helps to create the product in the proper language environment. 
   - Example: setting it to "fr" will create (or update) the product on fr.openfoodfacts.org. Image will also be selected as front_fr
- This PR also deals with the "countries where sold" field. Instead of feeding whatever the frontend gave, it now expects a comma-separated string of country codes, and converts them to their proper country taxonomy
    - Before: frontend sent "Norge", product was created with "Norge" (an invalid country)
    - Now: frontend should send "no", product will be created with "en:norway". Another example: "fr,be" -> "en:france,en:belgium"
    - If frontends sends something that doesn't match a two-letter code, country will be set to "en:world" instead (default value)

Related frontend PR https://github.com/openfoodfacts/open-prices-frontend/pull/1758