### PR TITLE
feat(Proofs): API: new endpoint to fetch a proof's history

### DIFF
--- a/open_prices/api/prices/serializers.py
+++ b/open_prices/api/prices/serializers.py
@@ -66,10 +66,5 @@ class PriceStatsSerializer(serializers.Serializer):
     price__avg = serializers.DecimalField(max_digits=10, decimal_places=2)
 
 
-class PriceHistorySerializer(serializers.Serializer):
-    history_id = serializers.IntegerField()
-    history_date = serializers.DateTimeField()
-    history_change_reason = serializers.CharField()
-    history_type = serializers.ChoiceField(choices=history.HISTORY_TYPE_CHOICES)
-    history_user_id = serializers.CharField()
-    changes = serializers.ListField()
+class PriceHistorySerializer(history.HistorySerializer):
+    pass

--- a/open_prices/api/proofs/serializers.py
+++ b/open_prices/api/proofs/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from open_prices.api.locations.serializers import LocationSerializer
+from open_prices.common import history
 from open_prices.locations.models import Location
 from open_prices.prices.models import Price
 from open_prices.proofs.models import (
@@ -88,6 +89,10 @@ class ProofProcessWithGeminiSerializer(serializers.Serializer):
     mode = (
         serializers.CharField()
     )  # TODO: this mode param should be used to select the prompt to execute, unimplemented for now
+
+
+class ProofHistorySerializer(history.HistorySerializer):
+    pass
 
 
 class PriceTagPredictionSerializer(serializers.ModelSerializer):

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -629,6 +629,30 @@ class ProofDeleteApiTest(TestCase):
         )
 
 
+class ProofHistoryApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_session_1 = SessionFactory()
+        cls.user_session_2 = SessionFactory()
+        cls.proof = ProofFactory(
+            **PROOF_RECEIPT, price_count=15, owner=cls.user_session_1.user.user_id
+        )
+        cls.url = reverse("api:proofs-history", args=[cls.proof.id])
+
+    def test_proof_history(self):
+        # 404
+        url = reverse("api:proofs-history", args=[999])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "No Proof matches the given query.")
+        # existing proof
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["history_type"], "+")
+        self.assertEqual(response.data[0]["changes"], [])
+
+
 class PriceTagListApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -24,6 +24,7 @@ from open_prices.api.proofs.serializers import (
     ProofCreateSerializer,
     ProofFullSerializer,
     ProofHalfFullSerializer,
+    ProofHistorySerializer,
     ProofProcessWithGeminiSerializer,
     ProofUpdateSerializer,
     ProofUploadSerializer,
@@ -229,6 +230,12 @@ class ProofViewSet(
             for sample_file in sample_files
         ]
         return Response({"labels": labels}, status=status.HTTP_200_OK)
+
+    @extend_schema(responses=ProofHistorySerializer(many=True))
+    @action(detail=True, methods=["GET"])
+    def history(self, request: Request, pk=None) -> Response:
+        proof = self.get_object()
+        return Response(proof.get_history_list(), status=200)
 
 
 class PriceTagViewSet(

--- a/open_prices/common/history.py
+++ b/open_prices/common/history.py
@@ -1,6 +1,7 @@
 from itertools import pairwise
 
 from django.core.management import call_command
+from rest_framework import serializers
 
 HISTORY_FIELDS = [
     "history_id",
@@ -91,3 +92,12 @@ def build_instance_history_list(instance):
     history_list.append(history_entry)
 
     return history_list
+
+
+class HistorySerializer(serializers.Serializer):
+    history_id = serializers.IntegerField()
+    history_date = serializers.DateTimeField()
+    history_change_reason = serializers.CharField()
+    history_type = serializers.ChoiceField(choices=HISTORY_TYPE_CHOICES)
+    history_user_id = serializers.CharField()
+    changes = serializers.ListField()


### PR DESCRIPTION
### What

Following https://github.com/openfoodfacts/open-prices/pull/1057, Similar to #1058

New `/proofs/<proof_id>/history` endpoint
