### PR TITLE
refactor(PriceTag): post-prediction, normalize barcodes

### DIFF
--- a/open_prices/prices/management/commands/normalize_barcodes.py
+++ b/open_prices/prices/management/commands/normalize_barcodes.py
@@ -1,7 +1,7 @@
 import argparse
 
 from django.core.management.base import BaseCommand
-from openfoodfacts import normalize_barcode
+from openfoodfacts.barcode import normalize_barcode
 
 from open_prices.prices.models import Price
 from open_prices.products.models import Product

--- a/open_prices/products/models.py
+++ b/open_prices/products/models.py
@@ -5,7 +5,7 @@ from django.db.models import Count, signals
 from django.dispatch import receiver
 from django.utils import timezone
 from django_q.tasks import async_task
-from openfoodfacts import normalize_barcode
+from openfoodfacts.barcode import normalize_barcode
 
 # Import custom lookups so that they are registered
 from open_prices.common import lookups  # noqa: F401

--- a/open_prices/proofs/ml.py
+++ b/open_prices/proofs/ml.py
@@ -19,6 +19,7 @@ import typing_extensions as typing
 from asgiref.sync import async_to_sync
 from django.conf import settings
 from google import genai
+from openfoodfacts.barcode import normalize_barcode
 from openfoodfacts.ml.image_classification import ImageClassifier
 from openfoodfacts.ml.object_detection import ObjectDetectionRawResult, ObjectDetector
 from openfoodfacts.types import JSONType
@@ -893,7 +894,7 @@ def run_and_save_price_tag_extraction(
                         barcode
                     )
             # normalize barcode
-            barcode = common_openfoodfacts.normalize_barcode(barcode)
+            barcode = normalize_barcode(barcode)
 
         # barcode similarity search is quite costly (500~1000ms for 4M
         # products), so we only run it if the barcode doesn't exist in the

--- a/scripts/shop_import/create_prices_from_csv.py
+++ b/scripts/shop_import/create_prices_from_csv.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 
-import openfoodfacts
+from openfoodfacts.barcode import normalize_barcode
 
 from open_prices.common import openfoodfacts as common_openfoodfacts
 from scripts.utils import create_price, is_valid_date, read_csv, read_json
@@ -73,7 +73,7 @@ def map_shop_price_list_to_open_prices(shop_price_list, shop_mapping_fields):
             shop_price, shop_mapping_fields, "product_code"
         )
         if open_prices_price["product_code"]:
-            open_prices_price["product_code"] = openfoodfacts.barcode.normalize_barcode(
+            open_prices_price["product_code"] = normalize_barcode(
                 open_prices_price["product_code"].strip()
             )
         # price (with cleanup)


### PR DESCRIPTION
### What

Similar to #1022 (where we added USD-specific post-prediction barcode cleaning)
And following https://github.com/openfoodfacts/open-prices/issues/1044

Also normalize predicted barcodes