### PR TITLE
feat(Prices): allow moderators to edit & delete any price

### DIFF
--- a/open_prices/common/permission.py
+++ b/open_prices/common/permission.py
@@ -1,0 +1,33 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class OnlyOwnerCanEditOrDelete(BasePermission):
+    """
+    Only allow owners to edit or delete an object.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+        return (
+            request.user
+            and request.user.is_authenticated
+            and (obj.owner == request.user.user_id)
+        )
+
+
+class OnlyOwnerOrModeratorCanEditOrDelete(BasePermission):
+    """
+    Only allow owners or moderators to edit or delete an object.
+    - only for non-safe methods
+    - (use only for Price or Proof objects)
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return True
+        return (
+            request.user
+            and request.user.is_authenticated
+            and ((obj.owner == request.user.user_id) or request.user.is_moderator)
+        )


### PR DESCRIPTION
### What

Closes #1088

Allow moderators to edit and delete prices

### How

- custom permission class `OnlyOwnerOrModeratorCanEditOrDelete`
- allows to clean the `get_queryset` method which was kinda weird (was returning 404s instead of 403 when non-owner where trying to edit existing prices)
- add tests