### PR TITLE
fix: set timeout properly for scheduled task

### DIFF
--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -170,6 +170,6 @@ for task_name, (task_cron, q_options) in CRON_SCHEDULES.items():
             name=task_name,
             schedule_type=Schedule.CRON,
             cron=task_cron,
-            q_options=q_options,
+            **q_options,
         )
         print(f"Task {task_name} scheduled with cron {task_cron}")


### PR DESCRIPTION
Following #1100

Contrary to the example in the documentation
(https://django-q2.readthedocs.io/en/master/schedules.html#schedule), passing timeout through `q_options` is ignored.

This was something that was already present in django-q package (https://github.com/Koed00/django-q/issues/332).

Passing timeout as a keyword argument works (I tested it), this fix is implemented here.