### PR TITLE
fix(Django): only import debug_toolbar if DEBUG (following #1106)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,4 +1,3 @@
-from debug_toolbar.toolbar import debug_toolbar_urls
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
@@ -10,4 +9,6 @@ urlpatterns = [
 ]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
+    from debug_toolbar.toolbar import debug_toolbar_urls
+
     urlpatterns += debug_toolbar_urls()


### PR DESCRIPTION
### What

In #1106 `django-debug-toolbar` was upgraded from v5 to v6.
Sentry is now raising RuntimeErrors.

More info here: https://github.com/django-commons/django-debug-toolbar/issues/2167