### PR TITLE
perf: increase the number of workers from 2 to 4

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -222,7 +222,7 @@ SPECTACULAR_SETTINGS = {
 
 Q_CLUSTER = {
     "name": "DjangORM",
-    "workers": 2,
+    "workers": 4,
     # timeout is set to 2h (OFF daily sync is long)
     "timeout": 2 * 60 * 60,
     # retry must be less than timeout & less than it takes to finish a task


### PR DESCRIPTION
### What

To allow more processing in parallel, and improve performances.
