### PR TITLE
refactor(Prices): set labels_tags & origins_tags to None or empty list depending on price type. Add tests

### DIFF
--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from freezegun import freeze_time
 from simple_history.utils import bulk_update_with_history
 
@@ -314,7 +314,7 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
                 )
 
 
-class PriceModelSaveTest(TestCase):
+class PriceModelSaveTest(TransactionTestCase):
     @classmethod
     def setUpTestData(cls):
         pass
@@ -420,6 +420,17 @@ class PriceModelSaveTest(TestCase):
         )
 
     def test_price_labels_tags_validation(self):
+        # TYPE_PRODUCT
+        for TUPLE_OK in [(None, None), ("", None), ([], None)]:
+            with self.subTest(TUPLE_OK=TUPLE_OK):
+                price = PriceFactory(
+                    type=price_constants.TYPE_PRODUCT,
+                    product_code="8001505005707",
+                    labels_tags=TUPLE_OK[0],
+                    price=5,
+                )
+                self.assertEqual(price.labels_tags, TUPLE_OK[1])
+        # TYPE_CATEGORY
         for TUPLE_OK in [
             (None, []),
             ("", []),
@@ -451,6 +462,7 @@ class PriceModelSaveTest(TestCase):
         for TUPLE_NOT_OK in [
             ("en:organic", json.JSONDecodeError),
             (5, TypeError),
+            ([""], ValidationError),
             (["en:organic", "test"], ValidationError),
         ]:
             with self.subTest(TUPLE_NOT_OK=TUPLE_NOT_OK):
@@ -465,6 +477,17 @@ class PriceModelSaveTest(TestCase):
                 )
 
     def test_price_origins_tags_validation(self):
+        # TYPE_PRODUCT
+        for TUPLE_OK in [(None, None), ("", None), ([], None)]:
+            with self.subTest(TUPLE_OK=TUPLE_OK):
+                price = PriceFactory(
+                    type=price_constants.TYPE_PRODUCT,
+                    product_code="8001505005707",
+                    origins_tags=TUPLE_OK[0],
+                    price=5,
+                )
+                self.assertEqual(price.origins_tags, TUPLE_OK[1])
+        # TYPE_CATEGORY
         for TUPLE_OK in [
             (None, []),
             ("", []),
@@ -486,6 +509,7 @@ class PriceModelSaveTest(TestCase):
         for TUPLE_NOT_OK in [
             ("en:france", json.JSONDecodeError),
             (5, TypeError),
+            ([""], ValidationError),
             (["en:france", "test"], ValidationError),
         ]:
             with self.subTest(TUPLE_NOT_OK=TUPLE_NOT_OK):

--- a/open_prices/prices/validators.py
+++ b/open_prices/prices/validators.py
@@ -43,6 +43,8 @@ def validate_price_product_code_or_category_tag_rules(instance):
                     field_name,
                     "Should not be set if `product_code` is filled",
                 )
+            # cleanup: unset
+            setattr(instance, field_name, None)
     elif instance.category_tag:
         if instance.type != price_constants.TYPE_CATEGORY:
             utils.add_validation_error(


### PR DESCRIPTION
### What

Improve data quality of "Category" fields (labels_tags & origins_tags)
- if TYPE_PRODUCT (product_code is set), set these fields to None
- if TYPE_CATEGORY (category_tag is set), default these fields to empty list ([])

### Stats

|Type|Total count|labels_tags|origins_tags|
|-|-|-|-|
|PRODUCT|143625|- None: 143550 ✅<br>- []: 75 ⚠️|- None: 143625 ✅<br>- []: 0 ✅|
|CATEGORY|6598|- None: 2954 ⚠️<br>- []: 903 ✅|- None: 285 ⚠️<br>- []: 165 ✅|