### PR TITLE
ci: fixes following the switch to ruff in #1150

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E203, E501, W503
-max-line-length = 88
-exclude = .git,__pycache__,build,dist,*_pb2.py,.venv
-max-doc-length = 79

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY --from=builder-dev $VENV_PATH $VENV_PATH
 COPY --from=builder-dev $POETRY_HOME $POETRY_HOME
 # Handle possible issue with Docker being too eager after copying files
 RUN true
-COPY .flake8 pyproject.toml ./
+COPY pyproject.toml ./
 # create folders that we mount in dev to avoid permission problems
 USER root
 RUN \

--- a/Makefile
+++ b/Makefile
@@ -105,29 +105,14 @@ toml-check:
 toml-lint:
 	${DOCKER_COMPOSE} run --rm --no-deps api poetry run toml-sort --in-place pyproject.toml
 
-flake8:
-	${DOCKER_COMPOSE} run --rm --no-deps api flake8
-
-black-check:
-	${DOCKER_COMPOSE} run --rm --no-deps api black --check .
-
-black:
-	${DOCKER_COMPOSE} run --rm --no-deps api black .
-
 mypy:
 	${DOCKER_COMPOSE} run --rm --no-deps api mypy .
-
-isort-check:
-	${DOCKER_COMPOSE} run --rm --no-deps api isort --check .
-
-isort:
-	${DOCKER_COMPOSE} run --rm --no-deps api isort .
 
 docs:
 	@echo "🥫 Generationg doc…"
 	${DOCKER_COMPOSE} run --rm --no-deps api ./build_mkdocs.sh
 
-checks: toml-check flake8 black-check mypy isort-check docs
+checks: toml-check mypy docs
 
 tests: django-tests
 

--- a/open_prices/moderation/tests.py
+++ b/open_prices/moderation/tests.py
@@ -115,7 +115,7 @@ class FlagModelSaveTest(TestCase):
                 source="unit-test",
             )
         # Using model.flags.create() on unsupported model
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(AttributeError):
             self.product.flags.create(
                 reason=FlagReason.OTHER,
                 comment="This product is weird",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ select = [
 
 
 ignore = [
-    "E501",
+    "E501",  # line too long (handled by ruff)
 
 ]
 


### PR DESCRIPTION
### What

Following #1150

- there was still some references to flake8
- 1 test was failing