### PR TITLE
refactor(Moderation): API: group endpoints together (in the swagger)

### DIFF
--- a/open_prices/api/moderation/views.py
+++ b/open_prices/api/moderation/views.py
@@ -1,4 +1,5 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, mixins, viewsets
 from rest_framework.permissions import IsAuthenticated
 
@@ -9,13 +10,13 @@ from open_prices.common.permission import OnlyModeratorIsAllowed
 from open_prices.moderation.models import Flag
 
 
+@extend_schema_view(
+    list=extend_schema(tags=["moderation"]),
+    partial_update=extend_schema(tags=["moderation"]),
+)
 class FlagViewSet(
     mixins.ListModelMixin, mixins.UpdateModelMixin, viewsets.GenericViewSet
 ):
-    """
-    Allow moderators to view all flags.
-    """
-
     authentication_classes = [CustomAuthentication]
     permission_classes = [IsAuthenticated, OnlyModeratorIsAllowed]
     http_method_names = ["get", "patch"]  # disable "put"

--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -94,7 +94,9 @@ class PriceViewSet(
         price = self.get_object()
         return Response(price.get_history_list(), status=200)
 
-    @extend_schema(request=FlagCreateSerializer, responses=FlagSerializer)
+    @extend_schema(
+        request=FlagCreateSerializer, responses=FlagSerializer, tags=["moderation"]
+    )
     @action(detail=True, methods=["POST"])
     def flag(self, request: Request, pk=None) -> Response:
         price = self.get_object()

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -202,7 +202,9 @@ class ProofViewSet(
         proof = self.get_object()
         return Response(proof.get_history_list(), status=200)
 
-    @extend_schema(request=FlagCreateSerializer, responses=FlagSerializer)
+    @extend_schema(
+        request=FlagCreateSerializer, responses=FlagSerializer, tags=["moderation"]
+    )
     @action(detail=True, methods=["POST"])
     def flag(self, request: Request, pk=None) -> Response:
         proof = self.get_object()


### PR DESCRIPTION
### What

tag "Moderation" endpoints to have them display together in the API docs (swagger)

### Screenshot

|Before|After|
|-|-|
|<img width="370" height="170" alt="image" src="https://github.com/user-attachments/assets/5a318f32-13a5-4572-a659-176484bcebf7" />|<img width="370" height="276" alt="image" src="https://github.com/user-attachments/assets/1be107d4-107c-4f4f-b7b2-e6f825597c0e" />|
