### PR TITLE
refactor(API): improve the Enum documentation (and avoid warnings) in the swagger

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -212,7 +212,12 @@ SPECTACULAR_SETTINGS = {
     },
     "SCHEMA_PATH_PREFIX": "/api/v[0-9]",
     "ENUM_NAME_OVERRIDES": {
-        "LocationOsmTypeEnum": "open_prices.locations.constants.OSM_TYPE_CHOICES"
+        "PriceTypeEnum": "open_prices.prices.constants.TYPE_CHOICES",
+        "ProofTypeEnum": "open_prices.proofs.constants.TYPE_CHOICES",
+        "PriceTagStatusEnum": "open_prices.proofs.constants.PRICE_TAG_STATUS_CHOICES",
+        "LocationTypeEnum": "open_prices.locations.constants.TYPE_CHOICES",
+        "LocationOsmTypeEnum": "open_prices.locations.constants.OSM_TYPE_CHOICES",
+        "FlagStatusEnum": "open_prices.moderation.models.FlagStatus.choices",
     },
 }
 

--- a/open_prices/api/challenges/serializers.py
+++ b/open_prices/api/challenges/serializers.py
@@ -1,12 +1,15 @@
 from rest_framework import serializers
 
 from open_prices.api.locations.serializers import LocationSerializer
+from open_prices.challenges import constants as challenge_constants
 from open_prices.challenges.models import Challenge
 
 
 class ChallengeSerializer(serializers.ModelSerializer):
     locations = LocationSerializer(many=True, read_only=True)
-    status = serializers.CharField(read_only=True)  # from model property
+    status = serializers.ChoiceField(
+        choices=challenge_constants.CHALLENGE_STATUS_CHOICES, read_only=True
+    )  # from model property
     tag = serializers.CharField(read_only=True)  # from model property
 
     class Meta:


### PR DESCRIPTION
### What

Avoid the following warnings when viewing the API docs (swagger)

```
Warning: enum naming encountered a non-optimally resolvable collision for fields named "status". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "StatusDe1Enum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
Warning: enum naming encountered a non-optimally resolvable collision for fields named "status". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "StatusEc7Enum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
Warning: enum naming encountered a non-optimally resolvable collision for fields named "type". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "TypeF36Enum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
Warning: enum naming encountered a non-optimally resolvable collision for fields named "type". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "TypeEbbEnum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
Warning: enum naming encountered a non-optimally resolvable collision for fields named "type". The same name has been used for multiple choice sets in multiple components. The collision was resolved with "TypeA9eEnum". add an entry to ENUM_NAME_OVERRIDES to fix the naming.
```