### PR TITLE
fix(Products): API: normalize code before fetching corresponding product

### DIFF
--- a/open_prices/api/products/tests.py
+++ b/open_prices/api/products/tests.py
@@ -153,6 +153,12 @@ class ProductDetailApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["id"], self.product.id)
+        # existing product with normalization
+        ProductFactory(code="0123456789100")
+        url = reverse("api:products-get-by-code", args=["123456789100"])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["code"], "0123456789100")
 
 
 class ProductCreateApiTest(TestCase):

--- a/open_prices/api/products/views.py
+++ b/open_prices/api/products/views.py
@@ -1,5 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from openfoodfacts import Flavor
+from openfoodfacts.barcode import normalize_barcode
 from rest_framework import filters, mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
@@ -38,6 +39,7 @@ class ProductViewSet(
 
     @action(detail=False, methods=["GET"], url_path=r"code/(?P<code>\d+)")
     def get_by_code(self, request: Request, code):
+        code = normalize_barcode(code)
         product = get_object_or_drf_404(Product, code=code)
         serializer = self.get_serializer(product)
         return Response(serializer.data)


### PR DESCRIPTION
### What

We already normalize incoming codes in different areas of the app
- when creating a product
- post-AI prediction on price tags

BUT we weren't doing it when users try to fetch a product by a given code.

cc @aleene
