### PR TITLE
feat(ml): upgrade to gemini-3-flash-preview

### DIFF
--- a/open_prices/common/google.py
+++ b/open_prices/common/google.py
@@ -19,7 +19,7 @@ GOOGLE_CLOUD_VISION_OCR_FEATURES = [
     "FACE_DETECTION",
 ]
 GEMINI_MODEL_NAME = "gemini"
-GEMINI_MODEL_VERSION = "gemini-2.5-flash"
+GEMINI_MODEL_VERSION = "gemini-3-flash-preview"
 
 
 @cache
@@ -58,20 +58,27 @@ def get_google_credentials() -> service_account.Credentials | None:
 
 
 def get_generation_config(
-    response_schema: type, thinking_budget: int = -1
+    response_schema: type,
+    thinking_budget: int | None = None,
+    thinking_level: str | None = None,
 ) -> types.GenerateContentConfig:
     """Return a generation configuration for the Gemini model.
+
+    For more information on thinking configurations for Gemini models, see
+    https://ai.google.dev/gemini-api/docs/thinking
 
     :param response_schema: The schema for the response. It can be a Pydantic
         model or a TypeDict.
     :param thinking_budget: The budget for the thinking process, in tokens.
-        0 is DISABLED. -1 is AUTOMATIC.
+    :param thinking_level: The level of thinking to include in the response.
     """
     return types.GenerateContentConfig(
         response_mime_type="application/json",
         response_schema=response_schema,
         thinking_config=types.ThinkingConfig(
-            thinking_budget=thinking_budget, include_thoughts=True
+            thinking_budget=thinking_budget,
+            thinking_level=thinking_level,
+            include_thoughts=True,
         ),
     )
 

--- a/open_prices/proofs/ml/receipts.py
+++ b/open_prices/proofs/ml/receipts.py
@@ -58,7 +58,9 @@ def extract_from_receipt(image: Image.Image) -> JSONType | None:
                 prompt,
                 image,
             ],
-            config=common_google.get_generation_config(Receipt),
+            config=common_google.get_generation_config(
+                Receipt, thinking_level="minimal"
+            ),
         )
     # Sometimes the response is not valid JSON, we try to parse it and return
     # None


### PR DESCRIPTION
Switch LLM model to gemini-3-flash-preview, for price tag and receipt extraction.
[Benchmarks](https://github.com/openfoodfacts/openfoodfacts-ai/blob/develop/llm-evals/reports/prices%3Aprice_tag_extraction/v1.2/report.md#summary-of-results) on price tags extraction showed that:

- Gemini 3 Flash Preview is the second best model after Gemini 3 Pro. It costs slightly more than Gemini 2.5 Flash, but is much more capable.
- Thinking has a very minor effect on performance, but is a significant part of the cost (given the higher price for output tokens)

In this PR, we switch to Gemini 3 Flash Preview and set thinking level to minimal (which means disabling it in most cases).