### PR TITLE
feat(Proofs): API: new filters by location (osm_id, osm_type, exact, in, type)

### DIFF
--- a/open_prices/api/proofs/filters.py
+++ b/open_prices/api/proofs/filters.py
@@ -1,6 +1,7 @@
 import django_filters
 
 from open_prices.common import constants
+from open_prices.locations import constants as location_constants
 from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.models import PriceTag, Proof, ReceiptItem
 
@@ -17,6 +18,10 @@ class ProofFilter(django_filters.FilterSet):
     kind = django_filters.ChoiceFilter(
         choices=constants.KIND_CHOICES,
         method="filter_kind",
+    )
+    location__type = django_filters.ChoiceFilter(
+        field_name="location__type",
+        choices=location_constants.TYPE_CHOICES,
     )
     tags__contains = django_filters.CharFilter(field_name="tags", lookup_expr="any")
 

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -220,6 +220,10 @@ class ProofListFilterApiTest(TestCase):
         url = self.url + "?location_id__isnull=false"
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 1 + 1)
+        # location__type
+        url = self.url + f"?location__type={location_constants.TYPE_ONLINE}"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1)
 
     def test_proof_list_filter_by_date(self):
         self.assertEqual(Proof.objects.count(), 3)


### PR DESCRIPTION
### What

- Most of the new filters were actually added in the previous PR: #1174
- Added tests
- Added a filter by `location__type`