### PR TITLE
fix(scheduler): increase timeout for specific task

### DIFF
--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -159,7 +159,7 @@ CRON_SCHEDULES = {
     ),
     "update_product_counts_task": (
         "20 2 * * 1",  # every start of the week (at 02:20)
-        {"timeout": 6 * 60 * 60},  # 6 hours
+        {"timeout": 10 * 60 * 60},  # 10 hours
     ),
 }
 


### PR DESCRIPTION
Increase timeout for update_product_counts_task.
This task takes more than 6 hours to complete now.