### PR TITLE
fix(scheduler): increase number of workers

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,9 @@ DEBUG=True
 # This is useful for local development, but should be set to False in production
 Q2_SYNC=False
 
+# Number of Q2 workers to run
+Q2_WORKERS = 8
+
 TAG=latest
 
 ALLOWED_HOSTS=localhost,127.0.0.1

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -163,6 +163,7 @@ jobs:
           echo "REDIS_PORT=${{ env.REDIS_PORT }}" >> .env
           echo "REDIS_PRODUCT_UPDATES_STREAM_NAME=product_updates" >> .env
           echo "ENABLE_REDIS_UPDATES=True" >> .env
+          echo "Q2_WORKERS=8" >> .env
 
     - name: Create Docker volumes
       uses: appleboy/ssh-action@master

--- a/config/settings.py
+++ b/config/settings.py
@@ -228,7 +228,7 @@ SPECTACULAR_SETTINGS = {
 
 Q_CLUSTER = {
     "name": "DjangORM",
-    "workers": 4,
+    "workers": int(os.getenv("Q2_WORKERS", 8)),
     # timeout is set to 2h (OFF daily sync is long)
     "timeout": 2 * 60 * 60,
     # retry must be less than timeout & less than it takes to finish a task

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ x-api-common: &api-common
     - SECRET_KEY
     - DEBUG
     - Q2_SYNC
+    - Q2_WORKERS
     - ALLOWED_HOSTS
     - CSRF_TRUSTED_ORIGINS
     - ENVIRONMENT


### PR DESCRIPTION
We now allow configuring using the `Q2_WORKERS` envvar the number of Q2 workers running.

Closes #1112.