### PR TITLE
refactor(Locations): API: cache the new osm countries response

### DIFF
--- a/open_prices/api/locations/views.py
+++ b/open_prices/api/locations/views.py
@@ -94,11 +94,11 @@ class LocationViewSet(
     def list_osm_countries(self, request):
         cache_key = "osm_countries_list"
         cache_timeout = 60 * 60 * 6  # 6 hours
-        countries = cache.get(cache_key)
+        countries_list = cache.get(cache_key)
 
-        if countries is None:
+        if countries_list is None:
             # get countries from JSON file
-            countries = utils.read_json(openstreetmap.COUNTRIES_JSON_PATH)
+            countries_list = utils.read_json(openstreetmap.COUNTRIES_JSON_PATH)
             # enrich with existing stats
             location_qs = (
                 Location.objects.filter(
@@ -108,8 +108,8 @@ class LocationViewSet(
                 .values("osm_address_country_code")
                 .annotate(location_count=Count("id"), price_count=Sum("price_count"))
             )
-            for i, country in enumerate(countries):
-                countries[i]["location_count"] = next(
+            for i, country in enumerate(countries_list):
+                countries_list[i]["location_count"] = next(
                     (
                         loc["location_count"]
                         for loc in location_qs
@@ -117,7 +117,7 @@ class LocationViewSet(
                     ),
                     0,
                 )
-                countries[i]["price_count"] = next(
+                countries_list[i]["price_count"] = next(
                     (
                         loc["price_count"]
                         for loc in location_qs
@@ -126,6 +126,6 @@ class LocationViewSet(
                     0,
                 )
             # cache results
-            cache.set(cache_key, countries, timeout=cache_timeout)
+            cache.set(cache_key, countries_list, timeout=cache_timeout)
 
-        return Response(countries)
+        return Response(countries_list)


### PR DESCRIPTION
### What

Following #1195

Cache the results from the API endpoint `/locations/osm/countries`
To avoid recalculating the counts on each query