### PR TITLE
fix: prevent foreign key violation for deleted proofs

### DIFF
--- a/open_prices/proofs/ml/__init__.py
+++ b/open_prices/proofs/ml/__init__.py
@@ -36,14 +36,6 @@ def run_and_save_proof_prediction(
     :param run_price_tag_extraction: whether to run the price tag extraction
         model on the detected price tags, defaults to True
     """
-    try:
-        proof = Proof.objects.get(id=proof.id)
-    except Proof.DoesNotExist:
-        logger.warning(
-            "Proof with id %s no longer exists, skipping ML prediction", proof.id
-        )
-        return None
-
     file_path_full = proof.file_path_full
 
     if file_path_full is None or not Path(file_path_full).exists():

--- a/open_prices/proofs/ml/price_tags.py
+++ b/open_prices/proofs/ml/price_tags.py
@@ -703,19 +703,23 @@ def run_and_save_price_tag_detection(
     else:
         max_confidence = None
 
-    proof_prediction = ProofPrediction.objects.create(
-        proof=proof,
-        type=proof_constants.PROOF_PREDICTION_OBJECT_DETECTION_TYPE,
-        model_name=PRICE_TAG_DETECTOR_MODEL_NAME,
-        model_version=PRICE_TAG_DETECTOR_MODEL_VERSION,
-        data={"objects": detections},
-        value=None,
-        max_confidence=max_confidence,
-    )
-    create_price_tags_from_proof_prediction(
-        proof, proof_prediction, run_extraction=run_extraction
-    )
-    return proof_prediction
+    try:
+        proof_prediction = ProofPrediction.objects.create(
+            proof=proof,
+            type=proof_constants.PROOF_PREDICTION_OBJECT_DETECTION_TYPE,
+            model_name=PRICE_TAG_DETECTOR_MODEL_NAME,
+            model_version=PRICE_TAG_DETECTOR_MODEL_VERSION,
+            data={"objects": detections},
+            value=None,
+            max_confidence=max_confidence,
+        )
+        create_price_tags_from_proof_prediction(
+            proof, proof_prediction, run_extraction=run_extraction
+        )
+        return proof_prediction
+    except Exception as e:
+        logger.exception(e)
+        return None
 
 
 def price_tag_prediction_has_predicted_barcode_valid(

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -820,22 +820,28 @@ class MLModelTest(TestCase):
                 ],
             )
 
-    def test_run_and_save_proof_prediction_proof_deleted(self):
-        proof = ProofFactory()
+    def test_run_and_save_price_tag_detection_proof_deleted(self):
+        proof = ProofFactory(type=proof_constants.TYPE_PRICE_TAG)
         proof_id = proof.id
         proof.delete()
-
         from open_prices.proofs.models import Proof
+
         deleted_proof = Proof(id=proof_id)
-
-        with self.assertLogs("open_prices.proofs.ml", level="WARNING") as cm:
-            result = run_and_save_proof_prediction(deleted_proof)
-            self.assertIsNone(result)
-            self.assertIn(
-                f"WARNING:open_prices.proofs.ml:Proof with id {proof_id} no longer exists, skipping ML prediction",
-                cm.output[0]
+        detect_price_tags_response = ObjectDetectionRawResult(
+            num_detections=1,
+            detection_boxes=np.array([[0.5, 0.5, 1.0, 1.0]]),
+            detection_classes=np.array([0], dtype=int),
+            detection_scores=np.array([0.98], dtype=np.float32),
+            label_names=["price-tag"],
+        )
+        with unittest.mock.patch(
+            "open_prices.proofs.ml.price_tags.detect_price_tags",
+            return_value=detect_price_tags_response,
+        ):
+            result = run_and_save_price_tag_detection(
+                self.image, deleted_proof, run_extraction=False
             )
-
+            self.assertIsNone(result)
 
     def test_run_and_save_proof_prediction_for_receipt_proof(self):
         predict_proof_type_response = [


### PR DESCRIPTION
**Signed-off-by**: Areeb Ahmed [areebshariff@acm.org](mailto:areebshariff@acm.org)

## Summary of Changes
- async prediction tasks fail with foreign key violations when proofs are deleted before task execution

## Related Issue(s)
Closes ~~#893~~ #798