### PR TITLE
chore: run single unit tests with Q2_SYNC=True

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ django-tests:
 
 django-tests-single: guard-args
 	@echo "🥫 Running specific tests …"
-	${DOCKER_COMPOSE_TEST} run --rm api poetry run python3 manage.py test -v 2 ${args}
+	${DOCKER_COMPOSE_TEST} run -e 'Q2_SYNC=True' --rm api poetry run python3 manage.py test -v 2 ${args}
 
 #------------#
 # Production #


### PR DESCRIPTION
This envvar was missing for `django-tests-single` command.

This was added in #1184, but it's better to keep it in a separate PR.