### PR TITLE
ci: also run test workflow on PRs coming from forks

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -2,6 +2,7 @@ name: Open Prices unit and integration tests
 
 on:
   push:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### What

Following a discussion in #1194

The `quality-check.yml` workflow is currently not run when a PR is opened from a fork