### PR TITLE
fix: ValueError when processing non-numeric barcodes in proof prediction

### DIFF
--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -347,6 +347,9 @@ def barcode_fix_short_codes_from_usa(barcode: str) -> str:
     :return: the 13-digit fixed and valid barcode, or the original barcode if
     it cannot be fixed
     """
+    if not barcode.isnumeric():
+        return barcode
+
     if len(barcode) in (10, 11, 12):
         barcode_temp = barcode.zfill(12)
         barcode_check_digit = openfoodfacts.barcode.calculate_check_digit(barcode + "0")

--- a/open_prices/common/tests.py
+++ b/open_prices/common/tests.py
@@ -123,6 +123,7 @@ class OpenFoodFactsTest(TestCase):
             ("71627004002", "0716270040027"),  # 11 digits (proof_id 48443)
             ("471058718081", "4710587180816"),  # 12 digits (proof_id 48849)
             ("2006050050833", "2006050050833"),  # 13 digits valid
+            ("S123456789", "S123456789"),  # non-numeric barcode should return as-is
         ]:
             with self.subTest(BARCODE_TUPLE=BARCODE_TUPLE):
                 self.assertEqual(


### PR DESCRIPTION
**Signed-off-by**: Areeb Ahmed [areebshariff@acm.org](mailto:areebshariff@acm.org)

## Summary of Changes
- Added check to ensure the barcode is numeric before calculating the check digit. Non-numeric barcodes are returned as-is.

## Related Issue(s)
Closes #1207