### PR TITLE
fix(prices): update counts when product/location/proof changes

### DIFF
--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -1088,9 +1088,9 @@ class PriceModelUpdateTest(TestCase):
         # after
         self.assertEqual(self.price.product_code, "8001505005707")
         product_8850187002197.refresh_from_db()
-        self.assertEqual(product_8850187002197.price_count, 1)  # TODO: should be 0
+        self.assertEqual(product_8850187002197.price_count, 0)  # We now enfore 0
         product_8001505005707 = Product.objects.get(code="8001505005707")
-        self.assertEqual(product_8001505005707.price_count, 0)  # TODO: should be 1
+        self.assertEqual(product_8001505005707.price_count, 1)  # We now enfore 1
         self.assertEqual(self.price.product, product_8001505005707)
 
 


### PR DESCRIPTION
## Description
Fixed a bug where `price_count` was not updated when a Price object was modified (e.g., when it was changed from one Product to another).

* Added `pre_save` signal to store original foreign keys.
* Updated `post_save` to detect changes and decrement/increment counts accordingly.
* Fixed `PriceModelUpdateTest`, which previously asserted incorrect values with a TODO comment.

## Type of change
- [x] Bug fix