### PR TITLE
feat(Locations): API: new cities endpoint that returns the list of cities for a given country code (ordered by name)

### DIFF
--- a/open_prices/api/locations/serializers.py
+++ b/open_prices/api/locations/serializers.py
@@ -32,4 +32,13 @@ class CountrySerializer(serializers.Serializer):
     id = serializers.IntegerField()
     name = serializers.CharField()
     country_code_2 = serializers.CharField()
-    osm_name = serializers.CharField(required=False, allow_null=True)
+    osm_name = serializers.CharField()
+    location_count = serializers.IntegerField()
+    price_count = serializers.IntegerField()
+
+
+class CountryCitySerializer(serializers.Serializer):
+    osm_name = serializers.CharField()
+    country_code_2 = serializers.CharField()
+    location_count = serializers.IntegerField()
+    price_count = serializers.IntegerField()

--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -284,6 +284,7 @@ class LocationOsmCountriesListApiTest(TestCase):
 
     def test_location_osm_countries(self):
         response = self.client.get(self.url)
+
         self.assertEqual(response.status_code, 200)
         self.assertTrue(isinstance(response.data, list))
         self.assertEqual(len(response.data), 238)
@@ -296,3 +297,44 @@ class LocationOsmCountriesListApiTest(TestCase):
         country_us = next(c for c in response.data if c["country_code_2"] == "US")
         self.assertEqual(country_us["location_count"], 0)
         self.assertEqual(country_us["price_count"], 0)
+
+
+class LocationOsmCountryCitiesListApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("api:locations-list-osm-country-cities", args=["FR"])
+        cls.location_fr_paris = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_address_country_code="FR",
+            osm_address_city="Paris",
+            price_count=5,
+        )
+        cls.location_fr_grenoble = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_address_country_code="FR",
+            osm_address_city="Grenoble",
+            price_count=10,
+        )
+        cls.location_fr_grenoble = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_address_country_code="FR",
+            osm_address_city="Grenoble",
+            price_count=0,
+        )
+        cls.location_ch_geneva = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_address_country_code="CH",
+            osm_address_city="Geneva",
+            price_count=0,
+        )
+
+    def test_location_osm_country_cities(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(isinstance(response.data, list))
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["osm_name"], "Grenoble")  # ordered by name
+        self.assertEqual(response.data[0]["country_code_2"], "FR")
+        self.assertEqual(response.data[0]["location_count"], 2)
+        self.assertEqual(response.data[0]["price_count"], 10)


### PR DESCRIPTION
### What

Following #1195 where we added a new cities endpoint: `/locations/osm/countries`

Here we add a new cities endpoint: `/locations/osm/countries/<country_code_2>/cities`
- returns the city's osm_name & country_code_2
- calculates the number of locations & prices

### Screenshot

<img width="630" height="404" alt="Screenshot from 2026-02-12 18-19-48" src="https://github.com/user-attachments/assets/dfd481c9-dd09-4b4b-856e-bdf317dc886f" />
