### PR TITLE
ci(Tests): avoid running the test CI twice when opening a PR

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,6 @@ name: Run pre-commit hooks
 
 on:
   pull_request:
-    branches: [ main ]
 
 jobs:
   pre-commit:

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -2,6 +2,8 @@ name: Open Prices unit and integration tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
### What

the `quality-check.yml` workflow was running on both `push` & `pull_request`.
I restricted the `push` config to just the `main` branch.
so that it is not triggered as well in PRs
