### PR TITLE
chore: update buildx version in container-build.yml workflow file

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        version: v0.6.0
+        version: v0.31.1
         buildkitd-flags: --debug
 
     - name: Login to DockerHub


### PR DESCRIPTION
- upgrade buildx version to 0.31.1: the version we used (0.6.0) was breaking the image build.