### PR TITLE
chore(docs): Remove .env copy instruction from INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,9 +11,6 @@
 # Clone repo
 git clone https://github.com/openfoodfacts/open-prices.git
 cd open-prices
-
-# Copy .env.example to .env
-
 ```
 
 ### Without Docker


### PR DESCRIPTION
### What
- Removed the outdated instruction `# Copy .env.example to .env` from `INSTALL.md`.
- The repository no longer contains a `.env.example` file, so this step caused confusion during local setup.
- This change ensures the installation documentation accurately reflects the current project structure.

### Screenshot
<!-- Not applicable – documentation-only change -->

### Fixes bug(s)
- N/A

### Part of 
- N/A