### PR TITLE
chore(docs): Fixing a typo in docker/dev.yml 

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -1,4 +1,4 @@
-# this file setup various thinks that are for dev environment
+# this file setup various things that are for dev environment
 
 x-api-base: &api-base
   image: openfoodfacts/open-prices/api:dev


### PR DESCRIPTION
### What
I was trying to setup the development environment and I found a small typo in the `docker/dev.yml` file. Sorry if this PR is annoying I couldn't help myself ignore the typo. 

### Screenshot
N/A

### Fixes bug(s)
N/A
### Part of 
N/A
