### PR TITLE
fix: Fixed .env file not loading when running manually

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,11 +2,13 @@
 """Django's command-line utility for administrative tasks."""
 
 import os
+from dotenv import load_dotenv
 import sys
 
 
 def main():
     """Run administrative tasks."""
+    load_dotenv()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:
         from django.core.management import execute_from_command_line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "pillow>=10.4.0,<11.0.0",
   "psycopg2-binary>=2.9.9,<2.10.0",
   "pydantic>=2.10.3,<2.11.0",
+  "python-dotenv>=1.2.1",
   "python-multipart>=0.0.7,<0.0.8",
   "requests>=2.32.5,<3.0.0",
   "sentry-sdk[django]>=2.43.0,<2.44.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1886,6 +1886,7 @@ dependencies = [
     { name = "pillow" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "requests" },
     { name = "sentry-sdk", extra = ["django"] },
@@ -1936,6 +1937,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.4.0,<11.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9,<2.10.0" },
     { name = "pydantic", specifier = ">=2.10.3,<2.11.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.7,<0.0.8" },
     { name = "requests", specifier = ">=2.32.5,<3.0.0" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.43.0,<2.44.0" },
@@ -2123,7 +2125,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2479,6 +2481,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What
Since the switch to `uv` it seems the environment has to be manually loaded using `--env-file` command in uv. This fix loads the env itself into the `manage.py` file using the`load_env()` function so there is no need to pass the argument manually in the command line while trying to run the server.

### Screenshot
#### Before 
<img width="1900" height="1028" alt="image" src="https://github.com/user-attachments/assets/ec1578a7-d7ca-4e70-be16-9d34be35ef77" />

#### After
<img width="1900" height="1028" alt="image" src="https://github.com/user-attachments/assets/42ffba81-6335-408f-a62b-a9a3b43e5265" />


### Fixes bug(s)
Fixes: #1241

### Part of 
N\A
