### PR TITLE
ci: on deploy, remove django static content before copying it again (fixes admin css)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ create_external_networks:
 
 cp-static-files:
 	@echo "🥫 Copying static files from api container to the host …"
-	docker cp open_prices-api-1:/opt/open-prices/static www/
+	rm -r www/static && docker cp open_prices-api-1:/opt/open-prices/static www/
 
 migrate-db:
 	@echo "🥫 Migrating database …"


### PR DESCRIPTION
I run this again in production, and the admin interface static content is back