### PR TITLE
feat(Prices): API: Filter on product source being null

### DIFF
--- a/open_prices/api/prices/filters.py
+++ b/open_prices/api/prices/filters.py
@@ -20,6 +20,9 @@ class PriceFilter(django_filters.FilterSet):
         field_name="product__source",
         choices=product_constants.SOURCE_CHOICES,
     )
+    product__source__isnull = django_filters.BooleanFilter(
+        field_name="product__source", lookup_expr="isnull"
+    )
     product__categories_tags__contains = django_filters.CharFilter(
         field_name="product__categories_tags",
         lookup_expr="any",

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -304,12 +304,13 @@ class PriceListFilterApiTest(TestCase):
         # product__source__isnull
         url = self.url + "?product__source__isnull=true"
         response = self.client.get(url)
-        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["total"], 4)
         self.assertEqual(response.data["items"][0]["category_tag"], "en:apples")
         # Products without source, but with a product id -> barcode products not yet created
-        url = self.url + "?product__source__isnull=false&product_id__isnull=false"
+        url = self.url + "?product__source__isnull=true&product_id__isnull=false"
         response = self.client.get(url)
-        self.assertEqual(response.data["total"], 0)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["product_code"], "8850187002197")
         # category_tag
         url = self.url + "?category_tag=apples"
         response = self.client.get(url)

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -301,6 +301,15 @@ class PriceListFilterApiTest(TestCase):
         url = self.url + "?product__source=off"
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 1)
+        # product__source__isnull
+        url = self.url + "?product__source__isnull=true"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["category_tag"], "en:apples")
+        # Products without source, but with a product id -> barcode products not yet created
+        url = self.url + "?product__source__isnull=false&product_id__isnull=false"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 0)
         # category_tag
         url = self.url + "?category_tag=apples"
         response = self.client.get(url)


### PR DESCRIPTION
### What
- Simple filter, we already could filter on a specific product source, but not the lack of it.
- Should help filtering prices of products yet to be created on Open Food Facts
