### PR TITLE
feat(OpenFoodFacts): new taxonomy helper method to get the full list of children from a parent list

### DIFF
--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -92,6 +92,8 @@ def get_taxonomy_children_tags_from_parent_list(
     :param parent_list: A list of parent tags (e.g., ["en:beverages"]).
     :param include_parent_list: Whether to include the parent tags in the result.
     :return: A list of all children tags (e.g., ["en:beverages", "en:sodas", "en:juices"]).
+
+    TODO: manage parent_list categories coming from different taxonomies (food & non-food)
     """
     taxonomy = _cached_get_taxonomy(taxonomy_type)
     children_tags = [] if not include_parent_list else list(parent_list)
@@ -100,9 +102,9 @@ def get_taxonomy_children_tags_from_parent_list(
     for parent in parent_list:
         parent_node = taxonomy[parent]
 
-        if not parent_node:
-            continue
-        if not parent_node.children:
+        # the parent node might not be in this taxonomy (e.g. non-food)
+        # the parent node might not have children
+        if not (parent_node and parent_node.children):
             continue
 
         for child_node in parent_node.children:

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -94,7 +94,7 @@ def get_taxonomy_children_tags_from_parent_list(
     :return: A list of all children tags (e.g., ["en:beverages", "en:sodas", "en:juices"]).
     """
     taxonomy = _cached_get_taxonomy(taxonomy_type)
-    children_tags = [] if not include_parent_list else parent_list
+    children_tags = [] if not include_parent_list else list(parent_list)
     seen = set()
 
     for parent in parent_list:

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -95,7 +95,7 @@ def get_taxonomy_children_tags_from_parent_list(
     """
     taxonomy = _cached_get_taxonomy(taxonomy_type)
     children_tags = [] if not include_parent_list else list(parent_list)
-    seen = set()
+    seen = set(children_tags)
 
     for parent in parent_list:
         parent_node = taxonomy[parent]

--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -53,15 +53,11 @@ _cached_get_taxonomy = functools.lru_cache()(get_taxonomy)
 def normalize_taxonomized_tags(taxonomy_type: str, value_tags: list[str]) -> list[str]:
     """Normalizes a list of tags based on the taxonomy type.
 
-    :param taxonomy_type: The type of taxonomy ('category', 'label', or
-        'origin').
-    :param value_tags: A list of tag values to normalize (e.g.,
-        ["fr: Boissons"]).
-    :raises RuntimeError: If the taxonomy type is not one of 'category',
-        'label', or 'origin'
+    :param taxonomy_type: The type of taxonomy ('category', 'label', or 'origin').
+    :param value_tags: A list of tag values to normalize (e.g. ["fr: Boissons"]).
+    :raises RuntimeError: If the taxonomy type is not one of 'category', 'label', or 'origin'
     :raises ValueError: If the value_tag could not be mapped to a canonical ID.
-    :return: The normalized tags (e.g., ["en:beverages"]). The order of the
-        tags is the same as the input list.
+    :return: The normalized tags (e.g., ["en:beverages"]). The order of the tags is the same as the input list.
     """
     if taxonomy_type not in ("category", "label", "origin"):
         raise RuntimeError(
@@ -85,6 +81,43 @@ def normalize_taxonomized_tags(taxonomy_type: str, value_tags: list[str]) -> lis
     mapped_tags = map_to_canonical_id(taxonomy_mapping, value_tags)
     # Keep the order of the tags as they were provided
     return [mapped_tags[k] for k in mapped_tags]
+
+
+def get_taxonomy_children_tags_from_parent_list(
+    taxonomy_type: str, parent_list: list[str], include_parent_list: bool = False
+) -> list[str]:
+    """Gets a list of all children for a given taxonomy type and parent list.
+
+    :param taxonomy_type: The type of taxonomy ('category', 'label', 'origin'...).
+    :param parent_list: A list of parent tags (e.g., ["en:beverages"]).
+    :param include_parent_list: Whether to include the parent tags in the result.
+    :return: A list of all children tags (e.g., ["en:beverages", "en:sodas", "en:juices"]).
+    """
+    taxonomy = _cached_get_taxonomy(taxonomy_type)
+    children_tags = [] if not include_parent_list else parent_list
+    seen = set()
+
+    for parent in parent_list:
+        parent_node = taxonomy[parent]
+
+        if not parent_node:
+            continue
+        if not parent_node.children:
+            continue
+
+        for child_node in parent_node.children:
+            if child_node.id not in seen:
+                children_tags.append(child_node.id)
+                seen.add(child_node.id)
+
+            for child_child_id in get_taxonomy_children_tags_from_parent_list(
+                taxonomy_type, [child_node.id]
+            ):
+                if child_child_id not in seen:
+                    children_tags.append(child_child_id)
+                    seen.add(child_child_id)
+
+    return children_tags
 
 
 def authenticate(username, password):


### PR DESCRIPTION
### What

See issue #1257
And with inspiration from a related PR #1261

New taxonomy helper method to extract the full chlidren list from a parent list.

Will be useful for challenges.

### Notes

- extra param `include_parent_list` to be sure to keep the parent as well sometimes
- it currently only takes 1 taxonomy at a time. so if the parent_list contain ids from different taxonomies, it won't be able to fetch all of their children

### Test

```
import time
from open_prices.common import openfoodfacts as common_openfoodfacts

start = time.time()
res = common_openfoodfacts.get_taxonomy_children_tags_from_parent_list("category", ["en:snacks", "en:office-supplies"], include_parent_list=True)
print(len(res))
end = time.time()
print(f"Execution time: {end - start}")

845
Execution time: 0.006926298141479492
```
