### PR TITLE
refactor(Challenges): match CATEGORY prices on categories_full (instead of categories)

### DIFF
--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -111,6 +111,12 @@ class PriceQuerySet(models.QuerySet):
         return self.filter(tags__contains=[tag])
 
     def in_challenge(self, challenge: Challenge):
+        """
+        Return prices that are in the given challenge, based on:
+        - the price creation date
+        - the price category tag or product categories tags (if the challenge has categories)
+        - the price location (if the challenge has locations)
+        """
         queryset = self.select_related("product").filter(
             created__gte=challenge.start_date_with_time,
             created__lte=challenge.end_date_with_time,
@@ -119,7 +125,7 @@ class PriceQuerySet(models.QuerySet):
             queryset = queryset.filter(
                 Q(
                     type=price_constants.TYPE_CATEGORY,
-                    category_tag__in=challenge.categories,
+                    category_tag__in=challenge.categories_full,
                 )
                 | Q(
                     type=price_constants.TYPE_PRODUCT,
@@ -377,32 +383,26 @@ class Price(models.Model):
             self._change_reason = "Price.update_tags() method"
             self.save(update_fields=["tags"])
 
-    def has_category_tag(self, category_tag_list: list):
-        if (
-            self.type == price_constants.TYPE_CATEGORY
-            and self.category_tag in category_tag_list
-        ):
-            return True
-        elif (
-            self.type == price_constants.TYPE_PRODUCT
-            and self.product
-            and self.product.categories_tags
-        ):
-            if set(self.product.categories_tags) & set(category_tag_list):
-                return True
-        return False
-
     def has_location(self, location_id_list: list):
         if self.location_id and self.location_id in location_id_list:
             return True
         return False
 
     def in_challenge(self, challenge: Challenge):
+        """
+        Mirror of the in_challenge queryset
+        """
         return (
             self.created >= challenge.start_date_with_time
             and self.created <= challenge.end_date_with_time
             and (
-                not challenge.categories or self.has_category_tag(challenge.categories)
+                not challenge.categories
+                or self.type == price_constants.TYPE_CATEGORY
+                and self.category_tag in challenge.categories_full
+                or self.type == price_constants.TYPE_PRODUCT
+                and self.product
+                and self.product.categories_tags
+                and set(self.product.categories_tags) & set(challenge.categories)
             )
             and (
                 not challenge.location_id_list()

--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -383,32 +383,36 @@ class Price(models.Model):
             self._change_reason = "Price.update_tags() method"
             self.save(update_fields=["tags"])
 
-    def has_location(self, location_id_list: list):
+    def has_location(self, location_id_list: list) -> bool:
         if self.location_id and self.location_id in location_id_list:
             return True
         return False
 
-    def in_challenge(self, challenge: Challenge):
+    def in_challenge(self, challenge: Challenge) -> bool:
         """
         Mirror of the in_challenge queryset
         """
-        return (
+        dates_match = (
             self.created >= challenge.start_date_with_time
             and self.created <= challenge.end_date_with_time
-            and (
-                not challenge.categories
-                or self.type == price_constants.TYPE_CATEGORY
+        )
+        categories_match = (
+            not challenge.categories
+            or (
+                self.type == price_constants.TYPE_CATEGORY
                 and self.category_tag in challenge.categories_full
-                or self.type == price_constants.TYPE_PRODUCT
-                and self.product
-                and self.product.categories_tags
-                and set(self.product.categories_tags) & set(challenge.categories)
             )
-            and (
-                not challenge.location_id_list()
-                or self.has_location(challenge.location_id_list())
+            or (
+                self.type == price_constants.TYPE_PRODUCT
+                and self.product
+                and bool(self.product.categories_tags)
+                and bool(set(self.product.categories_tags) & set(challenge.categories))
             )
         )
+        locations_match = not challenge.locations.exists() or (
+            self.location_id and self.location_id in challenge.location_id_list()
+        )
+        return dates_match and categories_match and locations_match
 
     def set_is_duplicate_of(self):
         """Look for duplicate prices and set the duplicate_of field

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -156,8 +156,9 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
             is_published=True,
             start_date="2024-12-30",
             end_date="2025-01-30",
-            categories=["en:breakfasts"],
+            categories=["en:viennoiseries"],
         )
+        print("categories_full", cls.challenge_ongoing_with_category.categories_full)
         cls.challenge_ongoing_with_location = ChallengeFactory(
             is_published=True,
             start_date="2024-12-30",
@@ -184,7 +185,12 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
             )
             cls.price_14 = PriceFactory(
                 type=price_constants.TYPE_CATEGORY,
-                category_tag="en:breakfasts",
+                category_tag="en:viennoiseries",
+                price_per=price_constants.PRICE_PER_UNIT,
+            )
+            cls.price_15 = PriceFactory(
+                type=price_constants.TYPE_CATEGORY,
+                category_tag="en:croissants",  # child of 'en:viennoiseries'
                 price_per=price_constants.PRICE_PER_UNIT,
             )
 
@@ -215,36 +221,13 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
             )
 
     def test_in_challenge_queryset(self):
-        self.assertEqual(Price.objects.count(), 10)
+        self.assertEqual(Price.objects.count(), 11)
         self.assertEqual(
-            Price.objects.in_challenge(self.challenge_ongoing_with_category).count(), 3
+            Price.objects.in_challenge(self.challenge_ongoing_with_category).count(), 4
         )
         self.assertEqual(
             Price.objects.in_challenge(self.challenge_ongoing_with_location).count(), 2
         )
-
-    def test_has_category_tag_property(self):
-        for price in Price.objects.all():
-            # challenge_ongoing_with_category
-            if price in [self.price_12, self.price_14, self.price_22, self.price_32]:
-                self.assertEqual(
-                    price.has_category_tag(
-                        self.challenge_ongoing_with_category.categories
-                    ),
-                    True,
-                )
-            else:
-                self.assertEqual(
-                    price.has_category_tag(
-                        self.challenge_ongoing_with_category.categories
-                    ),
-                    False,
-                )
-            # challenge_ongoing_with_location
-            self.assertEqual(
-                price.has_category_tag(self.challenge_ongoing_with_location.categories),
-                False,
-            )
 
     def test_has_location_property(self):
         for price in Price.objects.all():
@@ -274,7 +257,7 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
     def test_in_challenge_property(self):
         for price in Price.objects.all():
             # challenge_ongoing_with_category
-            if price in [self.price_12, self.price_14, self.price_22]:
+            if price in [self.price_12, self.price_14, self.price_22, self.price_15]:
                 self.assertEqual(
                     price.in_challenge(self.challenge_ongoing_with_category), True
                 )

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -156,9 +156,8 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
             is_published=True,
             start_date="2024-12-30",
             end_date="2025-01-30",
-            categories=["en:viennoiseries"],
+            categories=["en:spreads"],
         )
-        print("categories_full", cls.challenge_ongoing_with_category.categories_full)
         cls.challenge_ongoing_with_location = ChallengeFactory(
             is_published=True,
             start_date="2024-12-30",
@@ -185,12 +184,12 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
             )
             cls.price_14 = PriceFactory(
                 type=price_constants.TYPE_CATEGORY,
-                category_tag="en:viennoiseries",
+                category_tag="en:spreads",
                 price_per=price_constants.PRICE_PER_UNIT,
             )
             cls.price_15 = PriceFactory(
                 type=price_constants.TYPE_CATEGORY,
-                category_tag="en:croissants",  # child of 'en:viennoiseries'
+                category_tag="en:hazelnut-spreads",  # child of 'en:spreads'
                 price_per=price_constants.PRICE_PER_UNIT,
             )
 
@@ -257,7 +256,7 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
     def test_in_challenge_property(self):
         for price in Price.objects.all():
             # challenge_ongoing_with_category
-            if price in [self.price_12, self.price_14, self.price_22, self.price_15]:
+            if price in [self.price_12, self.price_14, self.price_15, self.price_22]:
                 self.assertEqual(
                     price.in_challenge(self.challenge_ongoing_with_category), True
                 )
@@ -278,7 +277,7 @@ class PriceChallengeQuerySetAndPropertyAndSignalTest(TestCase):
     def test_on_create_signal(self):
         for price in Price.objects.all():  # refresh_from_db
             # challenge_ongoing_with_category
-            if price in [self.price_12, self.price_14, self.price_22]:
+            if price in [self.price_12, self.price_14, self.price_15, self.price_22]:
                 self.assertIn(
                     f"challenge-{self.challenge_ongoing_with_category.id}", price.tags
                 )

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -104,6 +104,10 @@ class ProofQuerySet(models.QuerySet):
         return self.filter(tags__contains=[tag])
 
     def in_challenge(self, challenge: Challenge):
+        """
+        Return proofs that are in the given challenge, based on:
+        - if the proof has prices with the challenge tag
+        """
         return (
             self.prefetch_related("prices")
             .filter(prices__tags__contains=[challenge.tag])


### PR DESCRIPTION
### What

Following #1270 (new Categories.categories_full field).

We use this new field for price matching.
- only TYPE_CATEGORY prices (we consider that TYPE_PRODUCT product data has always the full category hierarchy)
- requires to update both the in_challenge queryset & property
