### PR TITLE
refactor(Challenges): improve daily update task to update categories_full & ignore past (completed) challenges

### DIFF
--- a/open_prices/challenges/models.py
+++ b/open_prices/challenges/models.py
@@ -359,4 +359,4 @@ def challenge_post_create_init_categories_full_and_stats(
 ):
     if created:
         instance.calculate_categories_full()
-        instance.calculate_stats()
+        instance.calculate_stats()  # init

--- a/open_prices/challenges/models.py
+++ b/open_prices/challenges/models.py
@@ -56,12 +56,15 @@ class ChallengeQuerySet(models.QuerySet):
 
     def to_update_in_daily_task(self):
         """
-        Goal: freeze completed challenges (categories, tags, stats) after a delay.
+        Goal: Choose which challenges stats we want to update.
+        - Data updated? categories_full, price/proof tags, stats
+        - We stop updating ("freeze") completed challenges after a delay
+
         Usage: see open_prices/common/tasks.py:challenge_tasks
         """
         CHALLENGE_COMPLETED_FREEZE_DELAY_IN_DAYS = 7
         return self.with_status().filter(
-            ~Q(status_annotated=challenge_constants.CHALLENGE_STATUS_COMPLETED)
+            Q(end_date=None)
             | Q(
                 end_date__gte=timezone.now().date()
                 - timedelta(days=CHALLENGE_COMPLETED_FREEZE_DELAY_IN_DAYS)

--- a/open_prices/challenges/models.py
+++ b/open_prices/challenges/models.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import ValidationError
 from django.db import models
-from django.db.models import Case, Count, F, Func, Value, When, signals
+from django.db.models import Case, Count, F, Func, Q, Value, When, signals
 from django.dispatch import receiver
 from django.utils import timezone
 
@@ -52,6 +52,20 @@ class ChallengeQuerySet(models.QuerySet):
     def is_ongoing(self):
         return self.with_status().filter(
             status_annotated=challenge_constants.CHALLENGE_STATUS_ONGOING
+        )
+
+    def to_update_in_daily_task(self):
+        """
+        Goal: freeze completed challenges (categories, tags, stats) after a delay.
+        Usage: see open_prices/common/tasks.py:challenge_tasks
+        """
+        CHALLENGE_COMPLETED_FREEZE_DELAY_IN_DAYS = 7
+        return self.with_status().filter(
+            ~Q(status_annotated=challenge_constants.CHALLENGE_STATUS_COMPLETED)
+            | Q(
+                end_date__gte=timezone.now().date()
+                - timedelta(days=CHALLENGE_COMPLETED_FREEZE_DELAY_IN_DAYS)
+            )
         )
 
 

--- a/open_prices/challenges/tests.py
+++ b/open_prices/challenges/tests.py
@@ -118,7 +118,7 @@ class ChallengeQuerySetTest(TestCase):
 class ChallengeStatusQuerySetAndPropertyTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.challenge_draft = ChallengeFactory(is_published=False)
+        cls.challenge_draft = ChallengeFactory(is_published=False, end_date=None)
         cls.challenge_upcoming = ChallengeFactory(
             is_published=True, start_date="2025-01-20", end_date="2025-02-20"
         )

--- a/open_prices/challenges/tests.py
+++ b/open_prices/challenges/tests.py
@@ -194,6 +194,21 @@ class ChallengeStatusQuerySetAndPropertyTest(TestCase):
         self.assertEqual(Challenge.objects.count(), 4)
         self.assertEqual(Challenge.objects.is_ongoing().count(), 1)
 
+    def test_challenge_to_update_in_daily_task_queryset(self):
+        self.assertEqual(Challenge.objects.count(), 4)
+        with freeze_time("2024-06-15"):
+            # challenge_completed hasn't started yet
+            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 4)
+        with freeze_time("2024-07-15"):
+            # challenge_completed is ongoing
+            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 4)
+        with freeze_time("2024-07-31"):
+            # challenge_completed has been over for less than X days
+            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 4)
+        with freeze_time("2025-01-01"):
+            # challenge_completed has been over for more than X days
+            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 3)
+
 
 class ChallengePropertyTest(TestCase):
     @classmethod

--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -116,10 +116,10 @@ def moderation_tasks():
 
 
 def challenge_tasks():
-    for challenge in Challenge.objects.all():
+    for challenge in Challenge.objects.to_update_in_daily_task():
         challenge.calculate_categories_full()
-        challenge.set_price_tags()
-        challenge.set_proof_tags()
+        challenge.set_price_tags()  # will only apply on 'ONGOING' challenges
+        challenge.set_proof_tags()  # will only apply based on price 'challenge' tags
         challenge.calculate_stats()
 
 

--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -117,6 +117,7 @@ def moderation_tasks():
 
 def challenge_tasks():
     for challenge in Challenge.objects.all():
+        challenge.calculate_categories_full()
         challenge.set_price_tags()
         challenge.set_proof_tags()
         challenge.calculate_stats()


### PR DESCRIPTION
### What

We already have a nightly task that updates EVERY challenge.

Following #1270 we now have a `Challenge.categories_full` field, that we would like to update regularly as the taxonomy evolves.

This PR changes the nightly task
- to include the `calculate_categories_full` method
- to ignore COMPLETED challenges after a delay of 7 days (freeze stats)