### PR TITLE
feat(Proofs): API: new endpoint to upload (and edit) "draft" proofs

### DIFF
--- a/open_prices/api/proofs/serializers.py
+++ b/open_prices/api/proofs/serializers.py
@@ -66,6 +66,16 @@ class ProofUploadSerializer(serializers.ModelSerializer):
         fields = ["file"] + Proof.CREATE_FIELDS
 
 
+class ProofDraftUploadSerializer(serializers.ModelSerializer):
+    """Serializer for draft proof upload - accepts only the file and type fields."""
+
+    file = serializers.FileField(required=True, use_url=False)
+
+    class Meta:
+        model = Proof
+        fields = ["file", "type"]
+
+
 class ProofCreateSerializer(serializers.ModelSerializer):
     location_id = serializers.PrimaryKeyRelatedField(
         queryset=Location.objects.all(), source="location", required=False

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -60,15 +60,16 @@ def create_fake_image(color: float | tuple[float] | str | None = "black") -> byt
 
 
 def clean_uploaded_proofs():
-    """Remove all images created during the test and all proofs/locations
-    in DB."""
+    """
+    Remove all images created during the test and all proofs/locations in DB.
+    """
     for file_name in os.listdir(settings.IMAGES_DIR):
         file_path = os.path.join(settings.IMAGES_DIR, file_name)
         if os.path.isfile(file_path):
             os.remove(file_path)
         else:
             shutil.rmtree(file_path)
-    Proof.objects.all().delete()
+    Proof.all_objects.all().delete()
     Location.objects.all().delete()
 
 
@@ -341,7 +342,7 @@ class ProofDetailApiTest(TestCase):
         )
 
 
-class ProofCreateApiTest(TestCase):
+class ProofUploadApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.url = reverse("api:proofs-upload")
@@ -841,10 +842,10 @@ class ProofFlagApiTest(TestCase):
         self.assertEqual(response.data["owner"], self.user_session_1.user.user_id)
 
 
-class DraftListApiTest(TestCase):
+class ProofDraftListApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.url = reverse("api:drafts-list")
+        cls.url = reverse("api:proofs-drafts-list")
         cls.user_1_session = SessionFactory()
         cls.user_2_session = SessionFactory()
         cls.user_1_draft_proof = ProofFactory(
@@ -856,6 +857,10 @@ class DraftListApiTest(TestCase):
         cls.user_1_non_draft_proof = ProofFactory(
             **PROOF_RECEIPT, owner=cls.user_1_session.user.user_id
         )
+
+    def test_proof_draft_list_unauthenticated_not_allowed(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
 
     def test_only_draft_proofs_returned(self):
         response = self.client.get(
@@ -879,12 +884,8 @@ class DraftListApiTest(TestCase):
         self.assertEqual(response.data["items"][0]["id"], self.user_2_draft_proof.id)
         self.assertNotEqual(response.data["items"][0]["id"], self.user_1_draft_proof.id)
 
-    def test_unauthenticated_not_allowed(self):
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 403)
 
-
-class DraftRetrieveApiTest(TestCase):
+class ProofDraftRetrieveApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user_1_session = SessionFactory()
@@ -899,30 +900,40 @@ class DraftRetrieveApiTest(TestCase):
             **PROOF_RECEIPT, owner=cls.user_1_session.user.user_id
         )
 
-    def test_not_returned_if_not_draft_proof(self):
-        url = reverse("api:drafts-detail", args=[self.user_1_non_draft_proof.id])
-        response = self.client.get(
-            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
-        )
-        self.assertEqual(response.status_code, 404)
-
-    def test_not_returned_if_created_by_someone_else(self):
-        url = reverse("api:drafts-detail", args=[self.user_2_draft_proof.id])
-        response = self.client.get(
-            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
-        )
-        self.assertEqual(response.status_code, 404)
-
-    def test_unauthenticated_not_allowed(self):
-        url = reverse("api:drafts-detail", args=[self.user_1_draft_proof.id])
+    def test_proof_draft_retrieve_unauthenticated_not_allowed(self):
+        url = reverse("api:proofs-drafts-detail", args=[self.user_1_draft_proof.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
+    def test_proof_draft_retrieve_not_returned_if_not_owner(self):
+        url = reverse("api:proofs-drafts-detail", args=[self.user_2_draft_proof.id])
+        response = self.client.get(
+            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
+        )
+        self.assertEqual(response.status_code, 404)
 
-class DraftUploadApiTest(TestCase):
+    def test_proof_draft_retrieve_not_returned_if_not_draft_proof(self):
+        url = reverse("api:proofs-drafts-detail", args=[self.user_1_non_draft_proof.id])
+        response = self.client.get(
+            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_proof_draft_retrieve_ok_if_draft_and_owner(self):
+        url = reverse("api:proofs-drafts-detail", args=[self.user_1_draft_proof.id])
+        response = self.client.get(
+            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["id"], self.user_1_draft_proof.id)
+        self.assertEqual(response.data["draft"], True)
+        self.assertEqual(response.data["owner"], self.user_1_session.user.user_id)
+
+
+class ProofDraftUploadApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.url = reverse("api:drafts-upload")
+        cls.url = reverse("api:proofs-drafts-upload")
         cls.user_session = SessionFactory()
         cls.data = {
             "file": create_fake_image(color="black"),
@@ -934,7 +945,15 @@ class DraftUploadApiTest(TestCase):
         clean_uploaded_proofs()
         super().tearDownClass()
 
-    def test_draft_upload_simple(self):
+    def test_proof_draft_upload_unauthenticated_not_allowed(self):
+        response = self.client.post(self.url, self.data)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.data,
+            {"detail": "Authentication credentials were not provided."},
+        )
+
+    def test_proof_draft_upload_ok(self):
         response = self.client.post(
             self.url,
             self.data,
@@ -946,16 +965,8 @@ class DraftUploadApiTest(TestCase):
         self.assertEqual(response.data["owner"], self.user_session.user.user_id)
         self.assertEqual(response.data["type"], proof_constants.TYPE_RECEIPT)
 
-    def test_draft_upload_unauthenticated(self):
-        response = self.client.post(self.url, self.data)
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(
-            response.data,
-            {"detail": "Authentication credentials were not provided."},
-        )
 
-
-class DraftPartialUpdateApiTest(TestCase):
+class ProofDraftPartialUpdateApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user_1_session = SessionFactory()
@@ -966,14 +977,28 @@ class DraftPartialUpdateApiTest(TestCase):
         cls.user_2_draft_proof = ProofFactory(
             draft=True, owner=cls.user_2_session.user.user_id
         )
-        cls.url = reverse("api:drafts-detail", args=[cls.user_1_draft_proof.id])
+        cls.url = reverse("api:proofs-drafts-detail", args=[cls.user_1_draft_proof.id])
 
     @classmethod
     def tearDownClass(cls):
         clean_uploaded_proofs()
         super().tearDownClass()
 
-    def test_draft_partial_update_required_fields_only(self):
+    def test_proof_draft_partial_update_forbidden_if_not_owner(self):
+        url = reverse("api:proofs-drafts-detail", args=[self.user_2_draft_proof.id])
+        data = {
+            "date": "2024-06-30",
+            "currency": "EUR",
+        }
+        response = self.client.patch(
+            url,
+            data,
+            headers={"Authorization": f"Bearer {self.user_1_session.token}"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_proof_draft_partial_update_required_fields_only(self):
         data = {
             "date": "2024-06-30",
             "currency": "EUR",
@@ -991,7 +1016,7 @@ class DraftPartialUpdateApiTest(TestCase):
         self.user_1_draft_proof.refresh_from_db()
         self.assertEqual(self.user_1_draft_proof.draft, False)
 
-    def test_draft_partial_update_all_fields(self):
+    def test_proof_draft_partial_update_all_fields(self):
         data = {
             "location_osm_id": LOCATION_OSM_NODE_652825274["osm_id"],
             "location_osm_type": LOCATION_OSM_NODE_652825274["osm_type"],
@@ -1018,19 +1043,39 @@ class DraftPartialUpdateApiTest(TestCase):
         self.user_1_draft_proof.refresh_from_db()
         self.assertEqual(self.user_1_draft_proof.draft, False)
 
-    def test_draft_partial_update_not_owner_forbidden(self):
-        url = reverse("api:drafts-detail", args=[self.user_2_draft_proof.id])
-        data = {
-            "date": "2024-06-30",
-            "currency": "EUR",
-        }
-        response = self.client.patch(
-            url,
-            data,
-            headers={"Authorization": f"Bearer {self.user_1_session.token}"},
-            content_type="application/json",
+
+class ProofDraftDeleteApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_1_session = SessionFactory()
+        cls.user_2_session = SessionFactory()
+        cls.user_1_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_1_session.user.user_id
+        )
+        cls.user_2_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_2_session.user.user_id
+        )
+        cls.url = reverse("api:proofs-drafts-detail", args=[cls.user_1_draft_proof.id])
+
+    @classmethod
+    def tearDownClass(cls):
+        clean_uploaded_proofs()
+        super().tearDownClass()
+
+    def test_proof_draft_delete_forbidden_if_not_owner(self):
+        url = reverse("api:proofs-drafts-detail", args=[self.user_2_draft_proof.id])
+        response = self.client.delete(
+            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_proof_draft_delete_ok_if_owner(self):
+        response = self.client.delete(
+            self.url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.data, None)
+        self.assertEqual(Proof.objects.filter(id=self.user_1_draft_proof.id).count(), 0)
 
 
 class PriceTagListApiTest(TestCase):
@@ -1172,7 +1217,7 @@ class PriceTagCreateApiTest(TestCase):
         cls.price = PriceFactory(proof=cls.proof)
         cls.default_bounding_box = [0.1, 0.2, 0.3, 0.4]
 
-    def test_price_tag_create_unauthenticated(self):
+    def test_price_tag_create_unauthenticated_not_allowed(self):
         response = self.client.post(
             self.url,
             data={"bounding_box": self.default_bounding_box, "proof_id": self.proof.id},
@@ -1262,7 +1307,7 @@ class PriceTagUpdateApiTest(TestCase):
         cls.url = reverse("api:price-tags-detail", args=[cls.price_tag.id])
         cls.new_bounding_box = [0.2, 0.3, 0.4, 0.5]
 
-    def test_price_tag_create_unauthenticated(self):
+    def test_price_tag_update_unauthenticated_not_allowed(self):
         response = self.client.patch(
             self.url,
             data={"bounding_box": self.new_bounding_box},
@@ -1383,7 +1428,7 @@ class PriceTagDeleteApiTest(TestCase):
             "api:price-tags-detail", args=[cls.price_tag_with_associated_price.id]
         )
 
-    def test_price_tag_delete_unauthenticated(self):
+    def test_price_tag_delete_unauthenticated_not_allowed(self):
         response = self.client.delete(self.url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -59,6 +59,19 @@ def create_fake_image(color: float | tuple[float] | str | None = "black") -> byt
     return fp
 
 
+def clean_uploaded_proofs():
+    """Remove all images created during the test and all proofs/locations
+    in DB."""
+    for file_name in os.listdir(settings.IMAGES_DIR):
+        file_path = os.path.join(settings.IMAGES_DIR, file_name)
+        if os.path.isfile(file_path):
+            os.remove(file_path)
+        else:
+            shutil.rmtree(file_path)
+    Proof.objects.all().delete()
+    Location.objects.all().delete()
+
+
 class ProofListApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -66,6 +79,12 @@ class ProofListApiTest(TestCase):
         cls.user_session = SessionFactory()
         cls.proof = ProofFactory(
             **PROOF_RECEIPT, price_count=15, owner=cls.user_session.user.user_id
+        )
+        # Draft proofs shouldn't be returned in the list
+        cls.draft_proof = ProofFactory(
+            type=proof_constants.TYPE_RECEIPT,
+            owner=cls.user_session.user.user_id,
+            draft=True,
         )
         cls.proof_prediction = ProofPredictionFactory(
             proof=cls.proof, type="CLASSIFICATION"
@@ -87,10 +106,14 @@ class ProofListApiTest(TestCase):
         with self.assertNumQueries(2):
             response = self.client.get(self.url)
             self.assertEqual(response.status_code, 200)
+            # Only 3 proofs, excluding the draft proof
             self.assertEqual(response.data["total"], 3)
             self.assertEqual(len(response.data["items"]), 3)
             item = response.data["items"][0]
             self.assertNotIn("predictions", item)  # not returned in "list"
+            self.assertNotIn(
+                self.draft_proof.id, [item["id"] for item in response.data["items"]]
+            )
 
 
 class ProofListOrderApiTest(TestCase):
@@ -332,18 +355,8 @@ class ProofCreateApiTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """Remove all images created during the test and all proofs/locations
-        in DB."""
-        for file_name in os.listdir(settings.IMAGES_DIR):
-            file_path = os.path.join(settings.IMAGES_DIR, file_name)
-            if os.path.isfile(file_path):
-                os.remove(file_path)
-            else:
-                shutil.rmtree(file_path)
+        clean_uploaded_proofs()
         super().tearDownClass()
-
-        Proof.objects.all().delete()
-        Location.objects.all().delete()
 
     def test_proof_create_wrong_endpoint(self):
         # anonymous
@@ -826,6 +839,198 @@ class ProofFlagApiTest(TestCase):
         self.assertEqual(response.data["comment"], "This proof is spam")
         self.assertEqual(response.data["status"], FlagStatus.OPEN)
         self.assertEqual(response.data["owner"], self.user_session_1.user.user_id)
+
+
+class DraftListApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("api:drafts-list")
+        cls.user_1_session = SessionFactory()
+        cls.user_2_session = SessionFactory()
+        cls.user_1_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_1_session.user.user_id
+        )
+        cls.user_2_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_2_session.user.user_id
+        )
+        cls.user_1_non_draft_proof = ProofFactory(
+            **PROOF_RECEIPT, owner=cls.user_1_session.user.user_id
+        )
+
+    def test_only_draft_proofs_returned(self):
+        response = self.client.get(
+            self.url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["items"][0]["id"], self.user_1_draft_proof.id)
+        self.assertNotEqual(
+            response.data["items"][0]["id"], self.user_1_non_draft_proof.id
+        )
+
+    def test_only_owner_proofs_returned(self):
+        response = self.client.get(
+            self.url, headers={"Authorization": f"Bearer {self.user_2_session.token}"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["items"][0]["id"], self.user_2_draft_proof.id)
+        self.assertNotEqual(response.data["items"][0]["id"], self.user_1_draft_proof.id)
+
+    def test_unauthenticated_not_allowed(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+
+class DraftRetrieveApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_1_session = SessionFactory()
+        cls.user_2_session = SessionFactory()
+        cls.user_1_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_1_session.user.user_id
+        )
+        cls.user_2_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_2_session.user.user_id
+        )
+        cls.user_1_non_draft_proof = ProofFactory(
+            **PROOF_RECEIPT, owner=cls.user_1_session.user.user_id
+        )
+
+    def test_not_returned_if_not_draft_proof(self):
+        url = reverse("api:drafts-detail", args=[self.user_1_non_draft_proof.id])
+        response = self.client.get(
+            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_not_returned_if_created_by_someone_else(self):
+        url = reverse("api:drafts-detail", args=[self.user_2_draft_proof.id])
+        response = self.client.get(
+            url, headers={"Authorization": f"Bearer {self.user_1_session.token}"}
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_unauthenticated_not_allowed(self):
+        url = reverse("api:drafts-detail", args=[self.user_1_draft_proof.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+
+class DraftUploadApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("api:drafts-upload")
+        cls.user_session = SessionFactory()
+        cls.data = {
+            "file": create_fake_image(color="black"),
+            "type": proof_constants.TYPE_RECEIPT,
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        clean_uploaded_proofs()
+        super().tearDownClass()
+
+    def test_draft_upload_simple(self):
+        response = self.client.post(
+            self.url,
+            self.data,
+            headers={"Authorization": f"Bearer {self.user_session.token}"},
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertIsNotNone(response.data["file_path"])
+        self.assertEqual(response.data["draft"], True)
+        self.assertEqual(response.data["owner"], self.user_session.user.user_id)
+        self.assertEqual(response.data["type"], proof_constants.TYPE_RECEIPT)
+
+    def test_draft_upload_unauthenticated(self):
+        response = self.client.post(self.url, self.data)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.data,
+            {"detail": "Authentication credentials were not provided."},
+        )
+
+
+class DraftPartialUpdateApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_1_session = SessionFactory()
+        cls.user_2_session = SessionFactory()
+        cls.user_1_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_1_session.user.user_id
+        )
+        cls.user_2_draft_proof = ProofFactory(
+            draft=True, owner=cls.user_2_session.user.user_id
+        )
+        cls.url = reverse("api:drafts-detail", args=[cls.user_1_draft_proof.id])
+
+    @classmethod
+    def tearDownClass(cls):
+        clean_uploaded_proofs()
+        super().tearDownClass()
+
+    def test_draft_partial_update_required_fields_only(self):
+        data = {
+            "date": "2024-06-30",
+            "currency": "EUR",
+        }
+        response = self.client.patch(
+            self.url,
+            data,
+            headers={"Authorization": f"Bearer {self.user_1_session.token}"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["draft"], False)
+        self.assertEqual(response.data["date"], "2024-06-30")
+        self.assertEqual(response.data["currency"], "EUR")
+        self.user_1_draft_proof.refresh_from_db()
+        self.assertEqual(self.user_1_draft_proof.draft, False)
+
+    def test_draft_partial_update_all_fields(self):
+        data = {
+            "location_osm_id": LOCATION_OSM_NODE_652825274["osm_id"],
+            "location_osm_type": LOCATION_OSM_NODE_652825274["osm_type"],
+            "type": proof_constants.TYPE_RECEIPT,
+            "currency": "USD",
+            "date": "2024-07-15",
+            "receipt_price_count": 10,
+            "receipt_price_total": "50.00",
+            "receipt_online_delivery_costs": "5.00",
+            "owner_consumption": True,
+            "owner_comment": "Test comment",
+        }
+        response = self.client.patch(
+            self.url,
+            data,
+            headers={"Authorization": f"Bearer {self.user_1_session.token}"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["draft"], False)
+        self.assertEqual(response.data["currency"], "USD")
+        self.assertEqual(response.data["date"], "2024-07-15")
+        self.assertEqual(response.data["receipt_price_count"], 10)
+        self.user_1_draft_proof.refresh_from_db()
+        self.assertEqual(self.user_1_draft_proof.draft, False)
+
+    def test_draft_partial_update_not_owner_forbidden(self):
+        url = reverse("api:drafts-detail", args=[self.user_2_draft_proof.id])
+        data = {
+            "date": "2024-06-30",
+            "currency": "EUR",
+        }
+        response = self.client.patch(
+            url,
+            data,
+            headers={"Authorization": f"Bearer {self.user_1_session.token}"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)
 
 
 class PriceTagListApiTest(TestCase):

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -1,12 +1,16 @@
 import PIL.Image
 from django.conf import settings
+from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from django_q.tasks import async_task
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters, mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import (
+    IsAuthenticated,
+    IsAuthenticatedOrReadOnly,
+)
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -21,6 +25,7 @@ from open_prices.api.proofs.serializers import (
     PriceTagFullSerializer,
     PriceTagUpdateSerializer,
     ProofCreateSerializer,
+    ProofDraftUploadSerializer,
     ProofFullSerializer,
     ProofHalfFullSerializer,
     ProofHistorySerializer,
@@ -35,11 +40,101 @@ from open_prices.common.authentication import (
     CustomAuthentication,
     has_token_from_cookie_or_header,
 )
-from open_prices.common.permission import OnlyObjectOwnerOrModeratorIsAllowedWrite
+from open_prices.common.permission import OnlyObjectOwnerIsAllowedReadWrite, OnlyObjectOwnerOrModeratorIsAllowedWrite
 from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.ml.price_tags import extract_from_price_tag
 from open_prices.proofs.models import PriceTag, Proof, ReceiptItem
 from open_prices.proofs.utils import compute_file_md5, store_file
+
+
+def base_upload(request: Request, draft: bool = False) -> Response:
+    # build proof
+    file = request.data.get("file")
+    if not file:
+        return Response(
+            {"file": ["This field is required."]},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    # NOTE: image will be stored even if the proof serializer fails...
+    file_path, mimetype, image_thumb_path = store_file(file)
+    image_md5_hash = compute_file_md5(file)
+    proof_create_data = {
+        "file_path": file_path,
+        "mimetype": mimetype,
+        "image_thumb_path": image_thumb_path,
+        "draft": draft,
+        **{
+            key: request.data.get(key)
+            for key in Proof.CREATE_FIELDS
+            if key in request.data
+        },
+    }
+    # validate
+    serializer = ProofCreateSerializer(data=proof_create_data)
+    serializer.is_valid(raise_exception=True)
+
+    # get owner (we allow anonymous upload, only if token is not present)
+    if request.user.is_authenticated:
+        owner = request.user.user_id
+    else:
+        if draft:
+            # It's not possible to upload a draft proof anonymously, as the user needs to be able to finalize it later
+            return Response(
+                {
+                    "detail": "Authentication is required to upload a draft proof. Please pass a valid token."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if has_token_from_cookie_or_header(request):
+            return Response(
+                {
+                    "detail": "Authentication failed. Please pass a valid token, or remove it to upload the proof anonymously."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        else:
+            owner = settings.ANONYMOUS_USER_ID
+
+    # get source
+    source = get_source_from_request(request)
+
+    # We check if a proof with the same MD5 hash already exists,
+    # uploaded by the same user, with the same type, location and date.
+    # If yes, we return it instead of creating a new one
+    duplicate_proof = Proof.objects.filter(
+        image_md5_hash=image_md5_hash,
+        owner=owner,
+        type=serializer.validated_data.get("type"),
+        # location OSM id/type can be null (for online stores)
+        location_osm_id=serializer.validated_data.get("location_osm_id"),
+        location_osm_type=serializer.validated_data.get("location_osm_type"),
+        date=serializer.validated_data.get("date"),
+    ).first()
+    if duplicate_proof:
+        # We remove the uploaded file as it's a duplicate
+        (settings.IMAGES_DIR / file_path).unlink(missing_ok=True)
+        response_status_code = status.HTTP_200_OK
+        # see note in common/openfoodfacts.py
+        if common_openfoodfacts.is_smoothie_app_version_leq_4_20(source):
+            response_status_code = status.HTTP_201_CREATED
+
+        return Response(
+            {**ProofFullSerializer(duplicate_proof).data, "detail": "duplicate"},
+            status=response_status_code,
+        )
+
+    save_kwargs = {
+        "owner": owner,
+        "image_md5_hash": image_md5_hash,
+        "source": source,
+    }
+    # see note in common/openfoodfacts.py
+    if common_openfoodfacts.is_smoothie_app_version_4_20(source):
+        save_kwargs["ready_for_price_tag_validation"] = False
+    # save
+    proof = serializer.save(**save_kwargs)
+    # return full proof
+    return Response(ProofFullSerializer(proof).data, status=status.HTTP_201_CREATED)
 
 
 class ProofViewSet(
@@ -69,7 +164,8 @@ class ProofViewSet(
         return [CustomAuthentication()]
 
     def get_queryset(self):
-        queryset = self.queryset
+        # Filter out draft proofs, as we use a dedicated draft endpoint to handle them
+        queryset = self.queryset.filter(draft=False)
         if self.request.method in ["GET"]:
             queryset = queryset.select_related("location")
             if self.action == "retrieve":
@@ -101,84 +197,7 @@ class ProofViewSet(
         permission_classes=[],  # allow anonymous upload
     )
     def upload(self, request: Request) -> Response:
-        # build proof
-        file = request.data.get("file")
-        if not file:
-            return Response(
-                {"file": ["This field is required."]},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        # NOTE: image will be stored even if the proof serializer fails...
-        file_path, mimetype, image_thumb_path = store_file(file)
-        image_md5_hash = compute_file_md5(file)
-        proof_create_data = {
-            "file_path": file_path,
-            "mimetype": mimetype,
-            "image_thumb_path": image_thumb_path,
-            **{
-                key: request.data.get(key)
-                for key in Proof.CREATE_FIELDS
-                if key in request.data
-            },
-        }
-        # validate
-        serializer = ProofCreateSerializer(data=proof_create_data)
-        serializer.is_valid(raise_exception=True)
-
-        # get owner (we allow anonymous upload, only if token is not present)
-        if self.request.user.is_authenticated:
-            owner = self.request.user.user_id
-        else:
-            if has_token_from_cookie_or_header(self.request):
-                return Response(
-                    {
-                        "detail": "Authentication failed. Please pass a valid token, or remove it to upload the proof anonymously."
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            else:
-                owner = settings.ANONYMOUS_USER_ID
-
-        # get source
-        source = get_source_from_request(self.request)
-
-        # We check if a proof with the same MD5 hash already exists,
-        # uploaded by the same user, with the same type, location and date.
-        # If yes, we return it instead of creating a new one
-        duplicate_proof = Proof.objects.filter(
-            image_md5_hash=image_md5_hash,
-            owner=owner,
-            type=serializer.validated_data.get("type"),
-            # location OSM id/type can be null (for online stores)
-            location_osm_id=serializer.validated_data.get("location_osm_id"),
-            location_osm_type=serializer.validated_data.get("location_osm_type"),
-            date=serializer.validated_data.get("date"),
-        ).first()
-        if duplicate_proof:
-            # We remove the uploaded file as it's a duplicate
-            (settings.IMAGES_DIR / file_path).unlink(missing_ok=True)
-            response_status_code = status.HTTP_200_OK
-            # see note in common/openfoodfacts.py
-            if common_openfoodfacts.is_smoothie_app_version_leq_4_20(source):
-                response_status_code = status.HTTP_201_CREATED
-
-            return Response(
-                {**ProofFullSerializer(duplicate_proof).data, "detail": "duplicate"},
-                status=response_status_code,
-            )
-
-        save_kwargs = {
-            "owner": owner,
-            "image_md5_hash": image_md5_hash,
-            "source": source,
-        }
-        # see note in common/openfoodfacts.py
-        if common_openfoodfacts.is_smoothie_app_version_4_20(source):
-            save_kwargs["ready_for_price_tag_validation"] = False
-        # save
-        proof = serializer.save(**save_kwargs)
-        # return full proof
-        return Response(ProofFullSerializer(proof).data, status=status.HTTP_201_CREATED)
+        return base_upload(request, draft=False)
 
     @extend_schema(request=ProofProcessWithGeminiSerializer)
     @action(
@@ -219,6 +238,84 @@ class ProofViewSet(
         return Response(FlagSerializer(flag).data, status=status.HTTP_201_CREATED)
 
 
+class DraftViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    authentication_classes = [CustomAuthentication]
+    permission_classes = [
+        IsAuthenticated,
+        OnlyObjectOwnerIsAllowedReadWrite,
+    ]
+    http_method_names = [
+        "get",
+        "post",
+        "patch",
+        "delete",
+    ]  # disable "put" (full update)
+    serializer_class = ProofFullSerializer
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_class = ProofFilter
+    ordering_fields = ["id", "date", "created"]
+    ordering = ["id"]
+
+    def get_queryset(self):
+        # Only keep draft proofs owned by the user
+        user_id = self.request.user.user_id
+        queryset = Proof.objects.filter(Q(draft=True) & Q(owner=user_id))
+        if self.request.method in ["GET"] and self.action == "retrieve":
+            queryset = queryset.prefetch_related("predictions")
+        return queryset
+
+    @extend_schema(request=ProofDraftUploadSerializer, responses=ProofFullSerializer)
+    @action(
+        detail=False,
+        methods=["POST"],
+        url_path="upload",
+        parser_classes=[MultiPartParser],
+    )
+    def upload(self, request: Request) -> Response:
+        """Upload a draft proof.
+
+        Only the file and type fields are expected. ML models runs immediately asynchronously."""
+        return base_upload(request, draft=True)
+
+    @extend_schema(request=ProofUpdateSerializer, responses=ProofFullSerializer)
+    def partial_update(self, request: Request, pk=None) -> Response:
+        """Finalize a draft proof - set draft=False and add full metadata."""
+        proof = self.get_object()
+        # Validate required fields
+        serializer = self.get_serializer(proof, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+
+        # Update fields
+        for field in Proof.UPDATE_FIELDS:
+            if field in serializer.validated_data:
+                setattr(proof, field, serializer.validated_data[field])
+
+        # Check required fields for finalization
+        missing_fields = []
+        if not proof.date:
+            missing_fields.append("date")
+        if not proof.currency:
+            missing_fields.append("currency")
+
+        if missing_fields:
+            return Response(
+                {"detail": f"Missing required fields: {', '.join(missing_fields)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        proof.draft = False
+        proof._change_reason = "Finalize draft proof"
+        proof.save()
+
+        return Response(ProofFullSerializer(proof).data, status=status.HTTP_200_OK)
+
+
 class PriceTagViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
@@ -246,12 +343,21 @@ class PriceTagViewSet(
         return [CustomAuthentication()]
 
     def get_queryset(self):
+        # Filter out draft proofs for non-owners
+        if self.request.user.is_authenticated:
+            user_id = self.request.user.user_id
+            base_queryset = self.queryset.filter(
+                Q(proof__draft=False) | Q(proof__owner=user_id)
+            )
+        else:
+            base_queryset = self.queryset.filter(proof__draft=False)
+
         if self.action in ["create", "update"]:
             # We need to prefetch the price object if it exists to validate the
             # price_id field, and the proof object to validate the proof_id
             # field
-            return PriceTag.objects.select_related("proof", "price").all()
-        return super().get_queryset()
+            return base_queryset.select_related("price")
+        return base_queryset
 
     def get_serializer_class(self):
         if self.request.method == "POST":

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -1,6 +1,5 @@
 import PIL.Image
 from django.conf import settings
-from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from django_q.tasks import async_task
 from drf_spectacular.utils import extend_schema
@@ -40,7 +39,10 @@ from open_prices.common.authentication import (
     CustomAuthentication,
     has_token_from_cookie_or_header,
 )
-from open_prices.common.permission import OnlyObjectOwnerIsAllowedReadWrite, OnlyObjectOwnerOrModeratorIsAllowedWrite
+from open_prices.common.permission import (
+    OnlyObjectOwnerIsAllowedReadWrite,
+    OnlyObjectOwnerOrModeratorIsAllowedWrite,
+)
 from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.ml.price_tags import extract_from_price_tag
 from open_prices.proofs.models import PriceTag, Proof, ReceiptItem
@@ -150,7 +152,7 @@ class ProofViewSet(
         OnlyObjectOwnerOrModeratorIsAllowedWrite,  # for edit & delete
     ]
     http_method_names = ["get", "post", "patch", "delete"]  # disable "put"
-    queryset = Proof.objects.all()
+    queryset = Proof.objects.all()  # proofs are already filtered out
     serializer_class = ProofFullSerializer  # see get_serializer_class
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filterset_class = ProofFilter
@@ -164,8 +166,7 @@ class ProofViewSet(
         return [CustomAuthentication()]
 
     def get_queryset(self):
-        # Filter out draft proofs, as we use a dedicated draft endpoint to handle them
-        queryset = self.queryset.filter(draft=False)
+        queryset = self.queryset
         if self.request.method in ["GET"]:
             queryset = queryset.select_related("location")
             if self.action == "retrieve":
@@ -238,7 +239,7 @@ class ProofViewSet(
         return Response(FlagSerializer(flag).data, status=status.HTTP_201_CREATED)
 
 
-class DraftViewSet(
+class ProofDraftViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
@@ -256,6 +257,7 @@ class DraftViewSet(
         "patch",
         "delete",
     ]  # disable "put" (full update)
+    queryset = Proof.all_objects.is_draft().all()  # only draft proofs
     serializer_class = ProofFullSerializer
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filterset_class = ProofFilter
@@ -263,12 +265,16 @@ class DraftViewSet(
     ordering = ["id"]
 
     def get_queryset(self):
+        queryset = self.queryset
         # Only keep draft proofs owned by the user
         user_id = self.request.user.user_id
-        queryset = Proof.objects.filter(Q(draft=True) & Q(owner=user_id))
+        queryset = queryset.filter(owner=user_id)
         if self.request.method in ["GET"] and self.action == "retrieve":
             queryset = queryset.prefetch_related("predictions")
         return queryset
+
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
     @extend_schema(request=ProofDraftUploadSerializer, responses=ProofFullSerializer)
     @action(
@@ -343,21 +349,12 @@ class PriceTagViewSet(
         return [CustomAuthentication()]
 
     def get_queryset(self):
-        # Filter out draft proofs for non-owners
-        if self.request.user.is_authenticated:
-            user_id = self.request.user.user_id
-            base_queryset = self.queryset.filter(
-                Q(proof__draft=False) | Q(proof__owner=user_id)
-            )
-        else:
-            base_queryset = self.queryset.filter(proof__draft=False)
-
         if self.action in ["create", "update"]:
             # We need to prefetch the price object if it exists to validate the
             # price_id field, and the proof object to validate the proof_id
             # field
-            return base_queryset.select_related("price")
-        return base_queryset
+            return PriceTag.objects.select_related("proof", "price").all()
+        return super().get_queryset()
 
     def get_serializer_class(self):
         if self.request.method == "POST":

--- a/open_prices/api/urls.py
+++ b/open_prices/api/urls.py
@@ -13,6 +13,7 @@ from open_prices.api.moderation.views import FlagViewSet
 from open_prices.api.prices.views import PriceViewSet
 from open_prices.api.products.views import ProductViewSet
 from open_prices.api.proofs.views import (
+    DraftViewSet,
     PriceTagViewSet,
     ProofViewSet,
     ReceiptItemViewSet,
@@ -28,6 +29,7 @@ router.register(r"v1/users", UserViewSet, basename="users")
 router.register(r"v1/locations", LocationViewSet, basename="locations")
 router.register(r"v1/products", ProductViewSet, basename="products")
 router.register(r"v1/proofs", ProofViewSet, basename="proofs")
+router.register(r"v1/drafts", DraftViewSet, basename="drafts")
 router.register(r"v1/prices", PriceViewSet, basename="prices")
 router.register(r"v1/price-tags", PriceTagViewSet, basename="price-tags")
 router.register(r"v1/receipt-items", ReceiptItemViewSet, basename="receipt-items")

--- a/open_prices/api/urls.py
+++ b/open_prices/api/urls.py
@@ -13,8 +13,8 @@ from open_prices.api.moderation.views import FlagViewSet
 from open_prices.api.prices.views import PriceViewSet
 from open_prices.api.products.views import ProductViewSet
 from open_prices.api.proofs.views import (
-    DraftViewSet,
     PriceTagViewSet,
+    ProofDraftViewSet,
     ProofViewSet,
     ReceiptItemViewSet,
 )
@@ -28,8 +28,8 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"v1/users", UserViewSet, basename="users")
 router.register(r"v1/locations", LocationViewSet, basename="locations")
 router.register(r"v1/products", ProductViewSet, basename="products")
+router.register(r"v1/proofs/drafts", ProofDraftViewSet, basename="proofs-drafts")
 router.register(r"v1/proofs", ProofViewSet, basename="proofs")
-router.register(r"v1/drafts", DraftViewSet, basename="drafts")
 router.register(r"v1/prices", PriceViewSet, basename="prices")
 router.register(r"v1/price-tags", PriceTagViewSet, basename="price-tags")
 router.register(r"v1/receipt-items", ReceiptItemViewSet, basename="receipt-items")

--- a/open_prices/common/permission.py
+++ b/open_prices/common/permission.py
@@ -19,7 +19,7 @@ class OnlyObjectOwnerIsAllowedWrite(BasePermission):
     - Gives write access ONLY to object owners
     """
 
-    def has_object_permission(self, request, view, obj):
+    def has_object_permission(self, request, view, obj) -> bool:
         if request.method in SAFE_METHODS:
             return True
         return request_user_is_object_owner(request, obj)

--- a/open_prices/common/permission.py
+++ b/open_prices/common/permission.py
@@ -19,7 +19,7 @@ class OnlyObjectOwnerIsAllowedWrite(BasePermission):
     - Gives write access ONLY to object owners
     """
 
-    def has_object_permission(self, request, view, obj) -> bool:
+    def has_object_permission(self, request, view, obj):
         if request.method in SAFE_METHODS:
             return True
         return request_user_is_object_owner(request, obj)


### PR DESCRIPTION
Here, we add a new `proof.draft` flag, that indicates that the proof is a "draft" (unfinished).

Draft proofs are not visible to any user but the user who uploaded it.

We only require for now the proof type when creating the draft proof, all other fields are optional. The advantage of draft proofs is to allow submitting immediately the image, as soon as the user select the proof to upload. Another advantage is that we run ML models immediately after upload. These model could be leveraged to help the user complete some proof-related information:

- date, number of items, total price, location (for receipts)
- currency

This also unlock the possibility to anonymize receipts, by first uploading the photo in draft mode (not available to other users), and then adding black rectangles to areas to anonymize.

Additional information (including currency, date and optional location) are send using the PATCH /proofs/finalize endpoint, the draft flag is removed during this step.

Draft proofs are deleted 1h after their creation date.

Related issue: https://github.com/openfoodfacts/open-prices/issues/958

Unit & integration tests were not added yet, I wanted to validate the features first.