### PR TITLE
ci(Release Please): move `docs` to a dedicated Documentation section

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,12 +21,12 @@
             "hidden": false
         },
         {
-            "type": "style",
-            "section": "Technical",
+            "type": "docs",
+            "section": "Documentation",
             "hidden": false
         },
         {
-            "type": "docs",
+            "type": "style",
             "section": "Technical",
             "hidden": false
         },


### PR DESCRIPTION
### What

Change `release please` config to have a dedicated "Documentation" section