### PR TITLE
refactor(Price Tags): ML: on manual price tag creation, also run classification. move the logic to a post_save signal

### DIFF
--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -280,12 +280,6 @@ class PriceTagViewSet(
         user_id = self.request.user.user_id
         price_tag = serializer.save(updated_by=user_id, created_by=user_id)
 
-        if not settings.TESTING:
-            async_task(
-                "open_prices.proofs.ml.price_tags.run_and_save_price_tag_extraction_from_id",
-                price_tag.id,
-            )
-
         # return full price tag
         return Response(
             self.serializer_class(price_tag).data, status=status.HTTP_201_CREATED

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -702,6 +702,21 @@ def price_tag_post_save_generate_image(sender, instance, created, **kwargs):
         generate_price_tag_image(instance)
 
 
+@receiver(signals.post_save, sender=PriceTag)
+def price_tag_post_save_run_ml_models(sender, instance, created, **kwargs):
+    """
+    Run price tag ML models
+    - only if created manually by a user
+    - if created automatically from a proof prediction, the classification & extraction is run in batch in run_and_save_proof_prediction
+    """
+    if not settings.TESTING:
+        if created and instance.created_by:
+            async_task(
+                "open_prices.proofs.ml.price_tags.run_and_save_price_tag_extraction_from_id",
+                instance.id,
+            )
+
+
 @receiver(signals.post_delete, sender=PriceTag)
 def price_tag_post_delete_remove_image(sender, instance, **kwargs):
     if os.path.exists(instance.image_path_full):

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -707,10 +707,14 @@ def price_tag_post_save_run_ml_models(sender, instance, created, **kwargs):
     """
     Run price tag ML models
     - only if created manually by a user
-    - if created automatically from a proof prediction, the classification & extraction is run in batch in run_and_save_proof_prediction
+    - if created automatically from a proof prediction, the models will be run (in batch) in run_and_save_proof_prediction
     """
     if not settings.TESTING:
         if created and instance.created_by:
+            async_task(
+                "open_prices.proofs.ml.price_tags.run_and_save_price_tag_classification_from_id",
+                instance.id,
+            )
             async_task(
                 "open_prices.proofs.ml.price_tags.run_and_save_price_tag_extraction_from_id",
                 instance.id,


### PR DESCRIPTION
### What

In #631 we added the logic of running price tag prediction model following a manual creation
And in #1308 we created a dedicated `run_and_save_price_tag_classification_from_id` method

In this PR we continue by
- moving this logic out of the view, and in the model (post_save signal)
- also run classification