### PR TITLE
fix(Locations): allow passing lat & lng as float or Decimal (and still be truncated)

### DIFF
--- a/open_prices/common/tests.py
+++ b/open_prices/common/tests.py
@@ -207,11 +207,16 @@ class UtilsTest(TestCase):
             self.assertFalse(is_float(PRICE_NOT_OK))
 
     def test_truncate_decimal(self):
+        # input: string
         self.assertEqual(truncate_decimal("0.1234567"), "0.1234567")
         self.assertEqual(truncate_decimal("0.123456789"), "0.1234567")
         self.assertEqual(
             truncate_decimal("0.123456789", max_decimal_places=9), "0.123456789"
         )
+        # input: float
+        self.assertEqual(truncate_decimal(0.123456789), Decimal("0.1234567"))
+        # input: Decimal
+        self.assertEqual(truncate_decimal(Decimal("0.123456789")), Decimal("0.1234567"))
 
     def test_match_decimal_with_float(self):
         self.assertTrue(match_decimal_with_float(Decimal("1"), 1))

--- a/open_prices/common/utils.py
+++ b/open_prices/common/utils.py
@@ -17,13 +17,26 @@ def is_float(string):
 
 
 def truncate_decimal(value, max_decimal_places=7):
+    """
+    Truncate a decimal value to a maximum number of decimal places.
+    - Input can be a string, a float or a Decimal.
+    - Output is of the same type as input.
+    """
     if value:
-        if type(value) is str:
-            if "." in value:
-                integer_part, decimal_part = value.split(".")
+        input_type = type(value)
+        if input_type in (str, float, Decimal):
+            value_str = (
+                str(value) if input_type is str else format(Decimal(str(value)), "f")
+            )
+            if "." in value_str:
+                integer_part, decimal_part = value_str.split(".")
                 if len(decimal_part) > max_decimal_places:
                     decimal_part = decimal_part[:max_decimal_places]
-                value = f"{integer_part}.{decimal_part}"
+                value_str = f"{integer_part}.{decimal_part}"
+            if input_type is str:
+                value = value_str
+            else:
+                value = Decimal(value_str)
     return value
 
 

--- a/open_prices/locations/tests.py
+++ b/open_prices/locations/tests.py
@@ -84,6 +84,7 @@ class LocationModelSaveTest(TestCase):
         )
 
     def test_location_decimal_truncate_on_create(self):
+        # input: string
         location = LocationFactory(
             **LOCATION_OSM_NODE_652825274,
             osm_lat="45.1805534",
@@ -92,6 +93,7 @@ class LocationModelSaveTest(TestCase):
         )
         self.assertEqual(location.osm_lat, Decimal("45.1805534"))
         self.assertEqual(location.osm_lon, Decimal("5.7153387"))
+        # see common.utils.tests for more truncate_decimal tests (with float and Decimal inputs)
 
     def test_location_online_validation(self):
         # website_url should be set


### PR DESCRIPTION
### What

When working on #1303 I realized that the `truncate_decimal` could only take string as input.
Improved to allow taking float & Decimal as well