### PR TITLE
ci(Release Please): use GITHUB_TOKEN with permissions (instead of PAT token)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-slim
@@ -12,7 +17,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5.0
         with:
-          # We can't use GITHUB_TOKEN here because, github actions can't provocate actions
-          # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          # So this is a personnal access token
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What

Simplify the Release Please Github Action
Use the default GITHUB_TOKEN + permissions

### Why

It worked here: https://github.com/openfoodfacts/brand-images/pull/40