### PR TITLE
ci(Release Please): revert to using RELEASE_PLEASE_TOKEN instead of GITHUB_TOKEN (wasn't triggering deployements)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-slim
@@ -17,4 +12,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # We can't use GITHUB_TOKEN here because, github actions can't provocate actions
+          # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          # So this is a personnal access token
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Reverts openfoodfacts/open-prices#1314