### PR TITLE
fix: improve error handling when fetching OFF product details

### DIFF
--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -1,6 +1,7 @@
 import datetime
 import functools
 import re
+from logging import getLogger
 
 import openfoodfacts
 import requests
@@ -24,6 +25,8 @@ from openfoodfacts.taxonomy import (
     map_to_canonical_id,
 )
 from openfoodfacts.types import COUNTRY_CODE_TO_NAME, JSONType
+
+logger = getLogger(__name__)
 
 OFF_CREATE_FIELDS = [
     "product_name",
@@ -206,16 +209,26 @@ def get_product(code: str, flavor: Flavor = Flavor.off) -> JSONType | None:
     return client.product.get(code)
 
 
-def get_product_dict(code: str, flavor=Flavor.off) -> JSONType | None:
-    product_dict = dict()
+def get_product_dict(code: str, flavor: Flavor = Flavor.off) -> JSONType | None:
+    """Get product information from Open Food Facts API.
+
+    If the product is not found, returns an empty dictionary.
+    If an error occurs, returns None.
+
+    :param code: the product code to look up
+    :param flavor: the flavor of the API to use (default: Flavor.off)
+    :return: a dictionary containing the product information, or None if an error
+        occurs
+    """
     try:
         response = get_product(code=code, flavor=flavor)
-        if response:
-            product_dict = build_product_dict(response, flavor)
-        return product_dict
     except Exception:
-        # logger.exception("Error returned from Open Food Facts")
+        logger.exception("Error returned from Open Food Facts")
         return None
+
+    if response:
+        return build_product_dict(response, flavor)
+    return {}
 
 
 def import_product_db(

--- a/open_prices/products/tasks.py
+++ b/open_prices/products/tasks.py
@@ -10,7 +10,14 @@ logger = logging.getLogger(__name__)
 
 def fetch_and_save_data_from_openfoodfacts(product: Product):
     product_openfoodfacts_details = common_openfoodfacts.get_product_dict(product.code)
-    if product_openfoodfacts_details:
+    if product_openfoodfacts_details is None:
+        # Call to Open Food Facts API failed
+        return
+    elif not product_openfoodfacts_details:
+        # Empty dict returned, product not found
+        logger.info("Product %s not found in Open Food Facts", product.code)
+        return
+    else:
         for key, value in product_openfoodfacts_details.items():
             setattr(product, key, value)
         product.save()
@@ -27,7 +34,16 @@ def process_update(code: str, flavor: Flavor) -> None:
     """
     product_openfoodfacts_details = common_openfoodfacts.get_product_dict(code, flavor)
 
-    if product_openfoodfacts_details:
+    if product_openfoodfacts_details is None:
+        # Call to Open Food Facts API failed
+        return
+    elif not product_openfoodfacts_details:
+        # Empty dict returned, product not found
+        logger.info(
+            "Product %s (flavor: %s) not found in Open Food Facts", code, flavor
+        )
+        return
+    else:
         does_not_exist = False
         try:
             product = Product.objects.get(code=code)


### PR DESCRIPTION
- update `get_product_dict` docstring to document explicitely the func behaviour: return None when API call fails and an empty dict when the product was not found.
- log exceptions in `get_product_dict` when fetching product data from OFF API
- In `build_product_dict`, only catch exceptions when calling OFF API: previously, exceptions in `build_product_dict` were silently catched and ignored.