### PR TITLE
refactor(Products): move sync task queryset to the model. Reduce the number of SQL calls

### DIFF
--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -7,7 +7,6 @@ import openfoodfacts
 import requests
 import tqdm
 from django.conf import settings
-from django.db.models import Q
 from django.utils import timezone
 from openfoodfacts import (
     API,
@@ -321,24 +320,18 @@ def import_product_db(
 
         # Case 2: existing product (already in OP database)
         else:
-            # Update the product if it:
-            # - is part of the current flavor sync (or if it has no source (created in Open Prices before OFF))  # noqa
-            # - has been updated since the last sync
-            existing_product_qs = (
-                Product.objects.filter(code=product_code)
-                .filter(Q(source=flavor) | Q(source=None))
-                .filter(
-                    Q(source_last_synced__lt=product_source_last_modified)
-                    | Q(source_last_synced=None)
+            # See product/models.py:ProductQuerySet.to_update_in_sync_task
+            existing_product_qs = Product.objects.to_update_in_sync_task(
+                code=product_code,
+                flavor=flavor,
+                product_source_last_modified=product_source_last_modified,
+            ).only("id")
+            # should be at most one (Product.code field is unique)
+            existing_product_qs_first = existing_product_qs.first()
+            if existing_product_qs_first:
+                products_to_update.append(
+                    Product(**{"id": existing_product_qs_first.id}, **product_dict)
                 )
-            )
-            if existing_product_qs.exists():
-                if existing_product_qs.count() == 1:
-                    products_to_update.append(
-                        Product(
-                            **{"id": existing_product_qs.first().id}, **product_dict
-                        )
-                    )
                 updated_count += 1
 
         # update the database regularly

--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -72,7 +72,7 @@ def update_product_counts_task():
     """
     Update product field counts
     """
-    for product in Product.objects.to_update_in_weekly_task():
+    for product in Product.objects.to_update_in_counts_task():
         product.update_price_count()
         product.update_location_count()
         product.update_user_count()

--- a/open_prices/products/models.py
+++ b/open_prices/products/models.py
@@ -1,7 +1,9 @@
+import datetime
+
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import Count, signals
+from django.db.models import Count, Q, signals
 from django.dispatch import receiver
 from django.utils import timezone
 from django_q.tasks import async_task
@@ -24,9 +26,28 @@ class ProductQuerySet(ApproximateCountQuerySet):
     def with_stats(self):
         return self.annotate(price_count_annotated=Count("prices", distinct=True))
 
-    def to_update_in_weekly_task(self):
+    def to_update_in_sync_task(
+        self, code: str, flavor: str, product_source_last_modified: datetime.datetime
+    ):
         """
-        Goal: only update products that have prices, to save (some) time.
+        Goal: OFF sync task, a product should be updated if:
+        - is part of the current flavor sync (or if it has no source (created in Open Prices before OFF))
+        - has been updated since the last sync (or has never been synced)
+
+        Usage: open_prices/common/openfoodfacts.py:import_product_db
+        """
+        return (
+            self.filter(code=code)
+            .filter(Q(source=flavor) | Q(source=None))
+            .filter(
+                Q(source_last_synced__lt=product_source_last_modified)
+                | Q(source_last_synced=None)
+            )
+        )
+
+    def to_update_in_counts_task(self):
+        """
+        Goal: only update counts of products that have prices, to save (some) time.
         We use the annotated price_count instead of the denormalized price_count field to be sure to have up-to-date information.
 
         Usage: open_prices/common/tasks.py:update_product_counts_task


### PR DESCRIPTION
### What

- New `Product.objects.to_update_in_sync_task` queryset. Taken from the existing OFF sync method.
- simplify the code to filter on the product to update (reduce SQL calls)

### Note

I did an extra check on the prod data, to be sure there are no "Product.code" duplicates
```
duplicates = (
    Product.objects.values('code')
    .annotate(code_count=Count('code'))
    .filter(code_count__gt=1)
)

print(duplicates.count())  # 0
```