### PR TITLE
refactor(Permissions): clarify read, write, object owner & moderator method names

### DIFF
--- a/open_prices/api/moderation/views.py
+++ b/open_prices/api/moderation/views.py
@@ -6,7 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 from open_prices.api.moderation.filters import FlagFilter
 from open_prices.api.moderation.serializers import FlagSerializer, FlagUpdateSerializer
 from open_prices.common.authentication import CustomAuthentication
-from open_prices.common.permission import OnlyModeratorIsAllowed
+from open_prices.common.permission import OnlyModeratorIsAllowedReadWrite
 from open_prices.moderation.models import Flag
 
 
@@ -18,7 +18,7 @@ class FlagViewSet(
     mixins.ListModelMixin, mixins.UpdateModelMixin, viewsets.GenericViewSet
 ):
     authentication_classes = [CustomAuthentication]
-    permission_classes = [IsAuthenticated, OnlyModeratorIsAllowed]
+    permission_classes = [IsAuthenticated, OnlyModeratorIsAllowedReadWrite]
     http_method_names = ["get", "patch"]  # disable "put"
     queryset = Flag.objects.all()
     serializer_class = FlagSerializer

--- a/open_prices/api/prices/views.py
+++ b/open_prices/api/prices/views.py
@@ -17,7 +17,7 @@ from open_prices.api.prices.serializers import (
 )
 from open_prices.api.utils import get_source_from_request
 from open_prices.common.authentication import CustomAuthentication
-from open_prices.common.permission import OnlyObjectOwnerOrModeratorIsAllowed
+from open_prices.common.permission import OnlyObjectOwnerOrModeratorIsAllowedWrite
 from open_prices.prices import constants as price_constants
 from open_prices.prices.models import Price
 
@@ -33,7 +33,7 @@ class PriceViewSet(
     authentication_classes = []  # see get_authenticators
     permission_classes = [
         IsAuthenticatedOrReadOnly,
-        OnlyObjectOwnerOrModeratorIsAllowed,  # for edit & delete
+        OnlyObjectOwnerOrModeratorIsAllowedWrite,  # for edit & delete
     ]
     http_method_names = ["get", "post", "patch", "delete"]  # disable "put"
     queryset = Price.objects.all()

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -35,7 +35,7 @@ from open_prices.common.authentication import (
     CustomAuthentication,
     has_token_from_cookie_or_header,
 )
-from open_prices.common.permission import OnlyObjectOwnerOrModeratorIsAllowed
+from open_prices.common.permission import OnlyObjectOwnerOrModeratorIsAllowedWrite
 from open_prices.proofs import constants as proof_constants
 from open_prices.proofs.ml.price_tags import extract_from_price_tag
 from open_prices.proofs.models import PriceTag, Proof, ReceiptItem
@@ -52,7 +52,7 @@ class ProofViewSet(
     authentication_classes = []  # see get_authenticators
     permission_classes = [
         IsAuthenticatedOrReadOnly,
-        OnlyObjectOwnerOrModeratorIsAllowed,  # for edit & delete
+        OnlyObjectOwnerOrModeratorIsAllowedWrite,  # for edit & delete
     ]
     http_method_names = ["get", "post", "patch", "delete"]  # disable "put"
     queryset = Proof.objects.all()

--- a/open_prices/common/permission.py
+++ b/open_prices/common/permission.py
@@ -13,9 +13,10 @@ def request_user_is_moderator(request) -> bool:
     return request.user and request.user.is_authenticated and request.user.is_moderator
 
 
-class OnlyObjectOwnerIsAllowed(BasePermission):
+class OnlyObjectOwnerIsAllowedWrite(BasePermission):
     """
-    Only give access to object owners.
+    - Gives read access to everyone
+    - Gives write access ONLY to object owners
     """
 
     def has_object_permission(self, request, view, obj):
@@ -24,9 +25,20 @@ class OnlyObjectOwnerIsAllowed(BasePermission):
         return request_user_is_object_owner(request, obj)
 
 
-class OnlyObjectOwnerOrModeratorIsAllowed(BasePermission):
+class OnlyObjectOwnerIsAllowedReadWrite(BasePermission):
     """
-    Only give access to object owners or moderators.
+    - Gives read access ONLY to object owners
+    - Gives write access ONLY to object owners
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return request_user_is_object_owner(request, obj)
+
+
+class OnlyObjectOwnerOrModeratorIsAllowedWrite(BasePermission):
+    """
+    - Gives read access to everyone
+    - Gives write access ONLY to object owners or moderators
     """
 
     def has_object_permission(self, request, view, obj):
@@ -37,9 +49,22 @@ class OnlyObjectOwnerOrModeratorIsAllowed(BasePermission):
         )
 
 
-class OnlyModeratorIsAllowed(BasePermission):
+class OnlyObjectOwnerOrModeratorIsAllowedReadWrite(BasePermission):
     """
-    Only give access to moderators.
+    - Gives read access ONLY to object owners or moderators
+    - Gives write access ONLY to object owners or moderators
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return request_user_is_object_owner(request, obj) or request_user_is_moderator(
+            request
+        )
+
+
+class OnlyModeratorIsAllowedReadWrite(BasePermission):
+    """
+    - Gives read access ONLY to moderators
+    - Gives write access ONLY to moderators
     """
 
     def has_permission(self, request, view):


### PR DESCRIPTION
### What

- rename OnlyObjectOwnerIsAllowed to OnlyObjectOwnerIsAllowedWrite
- rename OnlyObjectOwnerOrModeratorIsAllowed to OnlyObjectOwnerIsAllowedReadWrite
- rename OnlyModeratorIsAllowed to OnlyModeratorIsAllowedReadWrite
- add OnlyObjectOwnerOrModeratorIsAllowedWrite
- add more explicit explanations