### PR TITLE
fix(Price Tags): fix properties and tags computation when multiple prediction

### DIFF
--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -664,9 +664,7 @@ class PriceTag(models.Model):
         return False
 
     def get_prediction_from_type(self, type: str):
-        if self.predictions.exists():
-            return self.predictions.filter(type=type).first()
-        return None
+        return self.predictions.filter(type=type).first()
 
     def update_tags(self):
         changes = False

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -677,7 +677,9 @@ class PriceTag(models.Model):
             price_tag_prediction_has_predicted_product_exists,
         )
 
-        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        prediction = self.get_prediction_from_type(
+            proof_constants.PRICE_TAG_EXTRACTION_TYPE
+        )
         if prediction:
             if price_tag_prediction_has_predicted_barcode_valid(prediction):
                 changes = self.set_tag(
@@ -697,7 +699,9 @@ class PriceTag(models.Model):
             self.save(update_fields=["tags"])
 
     def get_predicted_price(self) -> float | None:
-        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        prediction = self.get_prediction_from_type(
+            proof_constants.PRICE_TAG_EXTRACTION_TYPE
+        )
         if prediction:
             if prediction.schema_version == "1.0":
                 return prediction.data.get("price")
@@ -706,13 +710,17 @@ class PriceTag(models.Model):
         return None
 
     def get_predicted_barcode(self):
-        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        prediction = self.get_prediction_from_type(
+            proof_constants.PRICE_TAG_EXTRACTION_TYPE
+        )
         if prediction:
             return prediction.data.get("barcode")
         return None
 
     def get_predicted_category(self):  # category_tag
-        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        prediction = self.get_prediction_from_type(
+            proof_constants.PRICE_TAG_EXTRACTION_TYPE
+        )
         if prediction:
             if prediction.schema_version == "1.0":
                 return prediction.data.get("product")
@@ -721,7 +729,9 @@ class PriceTag(models.Model):
         return None
 
     def get_predicted_product_name(self):
-        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        prediction = self.get_prediction_from_type(
+            proof_constants.PRICE_TAG_EXTRACTION_TYPE
+        )
         if prediction:
             return prediction.data.get("product_name")
         return None

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -663,6 +663,11 @@ class PriceTag(models.Model):
             return True
         return False
 
+    def get_prediction_from_type(self, type: str):
+        if self.predictions.exists():
+            return self.predictions.filter(type=type).first()
+        return None
+
     def update_tags(self):
         changes = False
         # prediction tags
@@ -672,8 +677,8 @@ class PriceTag(models.Model):
             price_tag_prediction_has_predicted_product_exists,
         )
 
-        if self.predictions.exists():
-            prediction = self.predictions.first()
+        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        if prediction:
             if price_tag_prediction_has_predicted_barcode_valid(prediction):
                 changes = self.set_tag(
                     proof_constants.PRICE_TAG_PREDICTION_TAG_BARCODE_VALID, save=False
@@ -692,8 +697,8 @@ class PriceTag(models.Model):
             self.save(update_fields=["tags"])
 
     def get_predicted_price(self) -> float | None:
-        if self.predictions.exists():
-            prediction = self.predictions.first()
+        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        if prediction:
             if prediction.schema_version == "1.0":
                 return prediction.data.get("price")
             elif prediction.schema_version == "2.0":
@@ -701,14 +706,14 @@ class PriceTag(models.Model):
         return None
 
     def get_predicted_barcode(self):
-        if self.predictions.exists():
-            prediction = self.predictions.first()
+        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        if prediction:
             return prediction.data.get("barcode")
         return None
 
     def get_predicted_category(self):  # category_tag
-        if self.predictions.exists():
-            prediction = self.predictions.first()
+        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        if prediction:
             if prediction.schema_version == "1.0":
                 return prediction.data.get("product")
             elif prediction.schema_version == "2.0":
@@ -716,8 +721,9 @@ class PriceTag(models.Model):
         return None
 
     def get_predicted_product_name(self):
-        if self.predictions.exists():
-            return self.predictions.first().data.get("product_name")
+        prediction = self.get_prediction_from_type(proof_constants.PRICE_TAG_EXTRACTION_TYPE)
+        if prediction:
+            return prediction.data.get("product_name")
         return None
 
 

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -42,7 +42,6 @@ from open_prices.proofs.factories import (
 from open_prices.proofs.ml import run_and_save_proof_prediction
 from open_prices.proofs.ml.classification import (
     proof_classification_model_config,
-    price_tag_classification_model_config,
     run_and_save_proof_type_prediction,
 )
 from open_prices.proofs.ml.ocr import fetch_and_save_ocr_data
@@ -1541,7 +1540,7 @@ class PriceTagPropertyTest(TestCase):
         self.assertEqual(self.price_tag_empty.get_predicted_barcode(), None)
         self.assertEqual(
             self.price_tag_with_multiple_predictions.get_predicted_barcode(),
-            "8001505005707"
+            "8001505005707",
         )
 
     def test_get_predicted_category(self):
@@ -1551,8 +1550,7 @@ class PriceTagPropertyTest(TestCase):
         )
         self.assertEqual(self.price_tag_empty.get_predicted_category(), None)
         self.assertEqual(
-            self.price_tag_with_multiple_predictions.get_predicted_category(),
-            "other"
+            self.price_tag_with_multiple_predictions.get_predicted_category(), "other"
         )
 
     def test_get_predicted_product_name(self):

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -42,6 +42,7 @@ from open_prices.proofs.factories import (
 from open_prices.proofs.ml import run_and_save_proof_prediction
 from open_prices.proofs.ml.classification import (
     proof_classification_model_config,
+    price_tag_classification_model_config,
     run_and_save_proof_type_prediction,
 )
 from open_prices.proofs.ml.ocr import fetch_and_save_ocr_data
@@ -1491,10 +1492,46 @@ class PriceTagPropertyTest(TestCase):
             data={},
         )
 
+        cls.price_tag_with_multiple_predictions = PriceTagFactory(
+            bounding_box=[0.1, 0.1, 0.2, 0.2],
+            proof=cls.proof,
+        )
+        PriceTagPrediction.objects.create(
+            price_tag=cls.price_tag_with_multiple_predictions,
+            type=proof_constants.PRICE_TAG_CLASSIFICATION_TYPE,
+            data={
+                "prediction": [
+                    {"label": "high-quality", "score": 0.96},
+                    {"label": "medium-quality", "score": 0.03},
+                    {"label": "invalid", "score": 0.01},
+                ]
+            },
+        )
+        PriceTagPrediction.objects.create(
+            price_tag=cls.price_tag_with_multiple_predictions,
+            type=proof_constants.PRICE_TAG_EXTRACTION_TYPE,
+            schema_version="2.0",
+            data={
+                "selected_price": {
+                    "price": 10,
+                    "wit_vat": True,
+                    "currency": "EUR",
+                    "price_per": "UNIT",
+                    "price_is_discounted": False,
+                },
+                "barcode": "8001505005707",
+                "category": "other",
+                "product_name": "NOCCIOLATA 700G",
+            },
+        )
+
     def test_get_predicted_price(self):
         self.assertEqual(self.price_tag_product.get_predicted_price(), 10)
         self.assertEqual(self.price_tag_category.get_predicted_price(), 2.5)
         self.assertEqual(self.price_tag_empty.get_predicted_price(), None)
+        self.assertEqual(
+            self.price_tag_with_multiple_predictions.get_predicted_price(), 10
+        )
 
     def test_get_predicted_barcode(self):
         self.assertEqual(
@@ -1502,6 +1539,10 @@ class PriceTagPropertyTest(TestCase):
         )
         self.assertEqual(self.price_tag_category.get_predicted_barcode(), "")
         self.assertEqual(self.price_tag_empty.get_predicted_barcode(), None)
+        self.assertEqual(
+            self.price_tag_with_multiple_predictions.get_predicted_barcode(),
+            "8001505005707"
+        )
 
     def test_get_predicted_category(self):
         self.assertEqual(self.price_tag_product.get_predicted_category(), "other")
@@ -1509,6 +1550,10 @@ class PriceTagPropertyTest(TestCase):
             self.price_tag_category.get_predicted_category(), "en:tomatoes"
         )
         self.assertEqual(self.price_tag_empty.get_predicted_category(), None)
+        self.assertEqual(
+            self.price_tag_with_multiple_predictions.get_predicted_category(),
+            "other"
+        )
 
     def test_get_predicted_product_name(self):
         self.assertEqual(
@@ -1519,6 +1564,10 @@ class PriceTagPropertyTest(TestCase):
             self.price_tag_category.get_predicted_product_name(), "TOMATES"
         )
         self.assertEqual(self.price_tag_empty.get_predicted_product_name(), None)
+        self.assertEqual(
+            self.price_tag_with_multiple_predictions.get_predicted_product_name(),
+            "NOCCIOLATA 700G",
+        )
 
 
 class PriceTagPredictionTest(TestCase):


### PR DESCRIPTION
Following #1284

### What
- I've noticed the frontend filter tag_prediction_product_exists was no longer working (showing no price tags)
- My guess is that the tag computation runs on the wrong prediction (clf instead of extraction)
- Indeed, the code is always looking for the `first` prediction, which now is the classification one
- I've also noticed that some of the PriceTag properties share the same broken predictions.first logic
- This PR properly loads the correct extraction prediction, if available, instead of the first one


Should fix the frontend display issue https://github.com/openfoodfacts/open-prices-frontend/issues/2216