### PR TITLE
docs(Community): add pages on Funding, Presentations & Project management

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -14,7 +14,7 @@ see [Slack](slack.md)
 
 ## Weekly meetings
 
-We e-meet Thrusdays at 14:00 Paris Time.
+We e-meet Thrusdays at 5PM Paris Time.
 
 see [Weekly meetings](weekly-meetings.md)
 

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -2,24 +2,38 @@
 
 Navigate the Open Prices community, get involved, and contribute!
 
-## Github
+## Code
 
-see [Github](github.md)
+see [Github](github.md) & [Changelog](CHANGELOG.md)
 
 ## Slack
 
-[https://openfoodfacts.slack.com](https://openfoodfacts.slack.com), channel `#prices`. Join us! See also [Slack](slack.md).
+[openfoodfacts.slack.com](https://openfoodfacts.slack.com), channel `#prices`. Join us!
+
+see [Slack](slack.md)
 
 ## Weekly meetings
 
-We e-meet Thrusdays at 14:00 Paris Time. More details in [weekly meetings](weekly-meetings.md).
+We e-meet Thrusdays at 14:00 Paris Time.
+
+see [Weekly meetings](weekly-meetings.md)
 
 ## Contribute
 
 - [Contributing](CONTRIBUTING.md)
 - [Install](INSTALL.md)
 - [UX & UI](ux-ui.md)
+- [Moderation](../topics/moderation-historisation.md)
+- [Project management](project-management.md)
 
-## Release Notes
+## Reuses
 
-see [Changelog](CHANGELOG.md)
+see [Reuses](reuses.md) & [Data](../guides/data.md)
+
+## Presentations
+
+see [Presentations](presentations.md)
+
+## Funding
+
+see [Funding](funding.md)

--- a/docs/community/funding.md
+++ b/docs/community/funding.md
@@ -2,6 +2,19 @@
 
 ## Open Food Facts
 
+The Open Food Facts organization has been the host of the Open Prices project since its inception.
+
+In taking this role, the non-profit has dedicated the following resources to the project:
+
+* Access to bare-metal servers to host part of the infrastructure
+* Coverage of costs of cloud-based solutions when required (mostly AI)
+* Tools for community animation
+* Stickers and other real life goodies
+* Slots during Open Food Facts related events
+* Human resources to maintain the infrastructure and contribute to the project (in technical and non-technical ways)
+
+To do so, the organization used its own funds, as well as funds directed to the Open Prices project, such as the one below.
+
 ## NLnet
 
 In 2025-2026 the Open Prices project received funding from [NLnet](https://nlnet.nl/), via the [NGI Zero Commons Fund](https://nlnet.nl/thema/NGI0CommonsFund.html).
@@ -10,9 +23,9 @@ NLnet is a non-profit organization that supports open source projects and initia
 
 Thanks to this funding, we worked on 3 main areas:
 
-* better machine learning tools to extract prices and barcodes from store shelf images (see [AI](../topics/ai/README.md))
-* moderation tools (see [Moderation & Historisation](../topics/moderation-historisation.md))
-* gamification (see [Gamification](../topics/gamification.md))
+* Better machine learning tools to extract prices and barcodes from store shelf images (see [AI](../topics/ai/README.md))
+* Moderation tools (see [Moderation & Historisation](../topics/moderation-historisation.md))
+* Gamification (see [Gamification](../topics/gamification.md))
 
 More info:
 
@@ -21,3 +34,7 @@ More info:
 * [Blog post](https://blog.openfoodfacts.org/en/news/open-prices-200000-prices-and-beyond) mentionning the funding
 
 ## Volunteer contributions
+
+While not strictly funding, volunteer contributions must be acknowledged, as the project couldn't exist without them.
+
+Rough estimates indicate that every 50 prices, one volunteer-hour was spent either adding them or building the infrastructure to do so efficiently. With more than a quarter million prices, that's the equivalent of a team of 3 to 4 working full-time on the project for a year.

--- a/docs/community/funding.md
+++ b/docs/community/funding.md
@@ -1,0 +1,23 @@
+# Funding
+
+## Open Food Facts
+
+## NLnet
+
+In 2025-2026 the Open Prices project received funding from [NLnet](https://nlnet.nl/), via the [NGI Zero Commons Fund](https://nlnet.nl/thema/NGI0CommonsFund.html).
+
+NLnet is a non-profit organization that supports open source projects and initiatives that contribute to a more open and secure internet. The NGI Zero Commons Fund is a funding program that supports projects that contribute to the development of the Next Generation Internet (NGI) and promote digital sovereignty.
+
+Thanks to this funding, we worked on 3 main areas:
+
+* better machine learning tools to extract prices and barcodes from store shelf images (see [AI](../topics/ai/README.md))
+* moderation tools (see [Moderation & Historisation](../topics/moderation-historisation.md))
+* gamification (see [Gamification](../topics/gamification.md))
+
+More info:
+
+* [NLnet project page](https://nlnet.nl/project/OpenPrices/)
+* [Github board](https://github.com/orgs/openfoodfacts/projects/161/views/2) to track progress
+* [Blog post](https://blog.openfoodfacts.org/en/news/open-prices-200000-prices-and-beyond) mentionning the funding
+
+## Volunteer contributions

--- a/docs/community/presentations.md
+++ b/docs/community/presentations.md
@@ -1,0 +1,14 @@
+# Presentations
+
+This page lists presentations about Open Prices, including slides, videos, and related materials.
+
+|Date|Place|Where|Links|
+|-|-|-|-|
+|19/02/2026|200k prices & news||[Blog post](https://blog.openfoodfacts.org/en/news/open-prices-200000-prices-and-beyond)|
+|31/01/2026|FOSDEM 2026 (Lightning Lightning talks)|Brussels|[Video](https://fosdem.org/2026/schedule/event/CNPVJL-lightning_lightning_talks_1/) (5 minutes), [Slides](https://fosdem.org/2026/events/attachments/CNPVJL-lightning_lightning_talks_1/slides/267016/open_pric_eojra1o.pdf)|
+|10/12/2025|OSXP 2025|Paris|[Youtube](https://youtu.be/4F7PggkrTlw) (20 minutes)|
+|18/06/2025|OW2'con 2025|Paris|[Youtube](https://youtu.be/eDCR7mo9Adw) (17 minutes)|
+|13/09/2025|Open Food Facts Days 2025|Paris||
+|29/11/2024|50k prices & news||[Blog post](https://blog.openfoodfacts.org/en/news/50k-prices-on-open-prices)|
+|21/09/2024|Open Food Facts Days 2024|Paris|[Youtube](https://youtu.be/3iTtKKhwopg) (11 minutes)|
+|03/02/2024|FOSDEM 2024 (Lightning talks)|Brussels|[Video](https://archive.fosdem.org/2024/schedule/event/fosdem-2024-3595-open-food-facts-acting-on-the-health-and-environnemental-impacts-of-the-food-system/) (last slides)|

--- a/docs/community/project-management.md
+++ b/docs/community/project-management.md
@@ -1,0 +1,6 @@
+# Project management
+
+* [Slack](slack.md)
+* [Weekly meetings](weekly-meetings.md)
+* [Roadmap](https://github.com/openfoodfacts/open-prices/issues/541) (to update)
+* [Funding](funding.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,13 +56,16 @@ nav:
   - Community:
     - Home: community/README.md
     - Github: community/github.md
+    - Changelog: community/CHANGELOG.md
     - Slack: community/slack.md
     - Weekly meetings: community/weekly-meetings.md
     - Contributing: community/CONTRIBUTING.md
     - Install: community/INSTALL.md
     - UX & UI: community/ux-ui.md
-    - Changelog: community/CHANGELOG.md
     - Reuses: community/reuses.md
+    - Project management: community/project-management.md
+    - Presentations: community/presentations.md
+    - Funding: community/funding.md
 
 plugins:
   - search


### PR DESCRIPTION
### What

Add more community-related documentation
- funding
- list of presentations
- project management

### Screenshot

<img width="911" height="598" alt="image" src="https://github.com/user-attachments/assets/4606ac3a-5857-4596-96cb-902ecbf93653" />
