### PR TITLE
feat: add API rate limiting

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -202,6 +202,14 @@ REST_FRAMEWORK = {
     "COERCE_DECIMAL_TO_STRING": False,  # return floats instead
     "DEFAULT_AUTHENTICATION_CLASSES": [],
     "DEFAULT_PERMISSION_CLASSES": [],
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+        "rest_framework.throttling.UserRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": "60/minute",
+        "user": "600/minute",
+    },
 }
 
 SPECTACULAR_SETTINGS = {

--- a/open_prices/api/tests.py
+++ b/open_prices/api/tests.py
@@ -1,6 +1,6 @@
 import base64
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 
 from open_prices.users.factories import SessionFactory
@@ -23,3 +23,41 @@ class StatusTest(TestCase):
                 response = self.client.get(self.url, headers=HEADERS_OK)
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), {"status": "running"})
+
+
+class RateLimitConfigTests(SimpleTestCase):
+    def test_anon_throttle_class_configured(self):
+        from django.conf import settings
+
+        throttle_classes = settings.REST_FRAMEWORK.get("DEFAULT_THROTTLE_CLASSES", [])
+        self.assertIn(
+            "rest_framework.throttling.AnonRateThrottle",
+            throttle_classes,
+        )
+
+    def test_user_throttle_class_configured(self):
+        from django.conf import settings
+
+        throttle_classes = settings.REST_FRAMEWORK.get("DEFAULT_THROTTLE_CLASSES", [])
+        self.assertIn(
+            "rest_framework.throttling.UserRateThrottle",
+            throttle_classes,
+        )
+
+    def test_anon_throttle_rate_set(self):
+        from django.conf import settings
+
+        throttle_rates = settings.REST_FRAMEWORK.get("DEFAULT_THROTTLE_RATES", {})
+        self.assertIn("anon", throttle_rates)
+
+    def test_user_throttle_rate_set(self):
+        from django.conf import settings
+
+        throttle_rates = settings.REST_FRAMEWORK.get("DEFAULT_THROTTLE_RATES", {})
+        self.assertIn("user", throttle_rates)
+
+    def test_pagination_max_page_size_enforced(self):
+        from open_prices.api.pagination import CustomPagination
+
+        self.assertIsNotNone(CustomPagination.max_page_size)
+        self.assertLessEqual(CustomPagination.max_page_size, 100)


### PR DESCRIPTION
## What
Fixes #1301 — adds DRF throttling to the API.

## Changes

### config/settings.py
Added throttle configuration to the REST_FRAMEWORK dict:
- Anonymous users: 60 requests/minute (per IP)
- Authenticated users: 600 requests/minute

### open_prices/api/tests.py
Added RateLimitConfigTests (5 tests, all passing) using SimpleTestCase
to avoid requiring a database connection.

### pagination.py
No change needed — max_page_size = 100 was already present.

## Notes
- Throttle rates (60/min anon, 600/min user) are starting points 
  based on OFF server's approach (anon limited, authenticated users 
  get more headroom). raphodn should tune based on actual traffic data.
- Used DRF's built-in AnonRateThrottle + UserRateThrottle — no new 
  dependencies required.
- Tests run without Docker/Postgres using SimpleTestCase.