### PR TITLE
refactor(Proofs): PriceTags: run ML in post_save instead of proof-specific code

### DIFF
--- a/docs/topics/ai/proof-prediction-flow.md
+++ b/docs/topics/ai/proof-prediction-flow.md
@@ -6,8 +6,8 @@ This document maps prediction-related operations for both proof and price tag cr
 
 ```mermaid
 graph TD
-    A["Proof.save()"] -->|"post_save signal"| B["proof_post_save_run_ocr<br/><b>ASYNC TASK via django-q</b>"]
-    A -->|"post_save signal"| C["proof_post_save_run_ml_models"]
+    A["Proof.save()"] -->|"post_save signal"| B["proof_post_create_run_ocr<br/><b>ASYNC TASK via django-q</b>"]
+    A -->|"post_save signal"| C["proof_post_create_run_ml_models"]
 
     B --> B1["fetch_and_save_ocr_data"]
 
@@ -37,7 +37,7 @@ graph TD
     J --> J1["extract_from_receipt<br/>Gemini API"]
     J1 --> J2["ProofPrediction.create<br/>type=PROOF_PREDICTION_RECEIPT_EXTRACTION"]
 
-    K["PriceTag.save() with created_by set"] -->|"post_save signal"| L["price_tag_post_save_run_ml_models<br/><b>ASYNC TASK via django-q</b>"]
+    K["PriceTag.save() with created_by set"] -->|"post_save signal"| L["price_tag_post_create_run_ml_models<br/><b>ASYNC TASK via django-q</b>"]
     L --> L1["run_and_save_price_tag_classification_from_id"]
     L --> L2["run_and_save_price_tag_extraction_from_id"]
     L1 --> G5

--- a/open_prices/proofs/management/commands/run_ml_models.py
+++ b/open_prices/proofs/management/commands/run_ml_models.py
@@ -149,8 +149,6 @@ class Command(BaseCommand):
                 self.stdout.write(f"Processing proof {proof.id}...")
                 run_and_save_proof_prediction(
                     proof,
-                    run_price_tag_classification=False,
-                    run_price_tag_extraction=False,
                     run_receipt_extraction="proof_receipt_extraction" in types,
                 )
                 self.stdout.write("Done.")

--- a/open_prices/proofs/ml/__init__.py
+++ b/open_prices/proofs/ml/__init__.py
@@ -22,8 +22,6 @@ logger = logging.getLogger(__name__)
 
 def run_and_save_proof_prediction(
     proof: Proof,
-    run_price_tag_classification: bool = True,
-    run_price_tag_extraction: bool = True,
     run_receipt_extraction: bool = True,
     run_async: bool = False,
 ) -> None:
@@ -31,15 +29,10 @@ def run_and_save_proof_prediction(
 
     Currently, the following models are run:
     - proof type classification model
-    - price tag classification model
-    - price tag extraction model
+    - price tag detection model
     - receipt extraction model
 
     :param proof: the Proof object to be classified
-    :param run_price_tag_classification: whether to run the price tag classification model on the
-        detected price tags, defaults to True
-    :param run_price_tag_extraction: whether to run the price tag extraction
-        model on the detected price tags, defaults to True
     :param run_receipt_extraction: whether to run the receipt extraction model, defaults to True
     :param run_async: whether to run the ML tasks asynchronously through Django Q, defaults to
         False (runs synchronously).
@@ -65,8 +58,6 @@ def run_and_save_proof_prediction(
                 "open_prices.proofs.ml.price_tags.run_and_save_price_tag_detection",
                 image=None,
                 proof=proof,
-                run_classification=run_price_tag_classification,
-                run_extraction=run_price_tag_extraction,
             )
         if run_receipt_extraction and proof.type == proof_constants.TYPE_RECEIPT:
             async_task(
@@ -85,11 +76,6 @@ def run_and_save_proof_prediction(
         run_and_save_proof_type_prediction(image, proof)
 
         if proof.type == proof_constants.TYPE_PRICE_TAG:
-            run_and_save_price_tag_detection(
-                image,
-                proof,
-                run_classification=run_price_tag_classification,
-                run_extraction=run_price_tag_extraction,
-            )
+            run_and_save_price_tag_detection(image, proof)
         if run_receipt_extraction and proof.type == proof_constants.TYPE_RECEIPT:
             run_and_save_receipt_extraction_prediction(image, proof)

--- a/open_prices/proofs/ml/price_tags.py
+++ b/open_prices/proofs/ml/price_tags.py
@@ -722,8 +722,6 @@ def create_price_tags_from_proof_prediction(
     proof: Proof,
     proof_prediction: ProofPrediction,
     threshold: float = 0.5,
-    run_classification: bool = True,
-    run_extraction: bool = True,
 ) -> list[PriceTag]:
     """Create price tags from a proof prediction containing price tag object
     detections. The following steps are performed:
@@ -738,10 +736,6 @@ def create_price_tags_from_proof_prediction(
         price tag detections
     :param threshold: the minimum confidence threshold for a detection to be
         considered valid, defaults to 0.5
-    :param run_classification: whether to run the price tag classification model on the
-        detected price tags, defaults to True
-    :param run_extraction: whether to run the price tag extraction model on the
-        detected price tags, defaults to True
     :return: the list of PriceTag instances created
     """
     if proof_prediction.model_name != PRICE_TAG_DETECTOR_MODEL_NAME:
@@ -752,14 +746,12 @@ def create_price_tags_from_proof_prediction(
         return []
 
     created_price_tags: list[PriceTag] = []
-    to_process: list[PriceTagWithImage] = []
     for detected_object in proof_prediction.data["objects"]:
         if detected_object["score"] < threshold:
             continue
         # To speed up preprocessing, we only crop the image once here, for both model
         # (price tag classification and extraction)
         bounding_box = detected_object["bounding_box"]
-        cropped_image = crop_image(proof.file_path_full, bounding_box)
         price_tag = PriceTag.objects.create(
             proof=proof,
             proof_prediction=proof_prediction,
@@ -770,32 +762,6 @@ def create_price_tags_from_proof_prediction(
             tags=[],
         )
         created_price_tags.append(price_tag)
-        price_tag_with_image = PriceTagWithImage(price_tag, cropped_image)
-
-        if run_classification:
-            classification = run_and_save_price_tag_classification(
-                cropped_image,
-                price_tag,
-            )
-            if not classification:
-                continue
-            predicted_price_tag_type = classification.data.get("prediction", [{}])[
-                0
-            ].get("label")
-
-            # Price tag type prediction can have three possible values: "invalid",
-            # "medium-quality" and "high-quality". We only run the extraction model
-            # on price tags that are not predicted as "invalid" as there is nothing
-            # to extract on these image crops: either the price tag is too blurry or
-            # the crop is not actually a price tag.
-            if predicted_price_tag_type != "invalid":
-                to_process.append(price_tag_with_image)
-        else:
-            # If we don't run classification, we run extraction on all detected price tags
-            to_process.append(price_tag_with_image)
-
-    if run_extraction:
-        run_and_save_price_tag_extraction(to_process, proof)
 
     return created_price_tags
 
@@ -804,8 +770,6 @@ def run_and_save_price_tag_detection(
     image: np.ndarray | None,
     proof: Proof,
     overwrite: bool = False,
-    run_classification: bool = True,
-    run_extraction: bool = True,
 ) -> ProofPrediction | None:
     """Run the price tag object detection model and save the prediction
     in ProofPrediction table.
@@ -815,10 +779,6 @@ def run_and_save_price_tag_detection(
     :param proof: the Proof instance to associate the ProofPrediction with
     :param overwrite: whether to overwrite existing prediction, defaults to
         False
-    :param run_classification: whether to run the price tag classification model on the
-        detected price tags, defaults to True
-    :param run_extraction: whether to run the price tag extraction model on the
-        detected price tags, defaults to True
     :return: the ProofPrediction instance created, or None if the prediction
         already exists and overwrite is False
     """
@@ -847,12 +807,7 @@ def run_and_save_price_tag_detection(
                     "Creating price tags from existing prediction for proof %s",
                     proof.id,
                 )
-                create_price_tags_from_proof_prediction(
-                    proof,
-                    proof_prediction,
-                    run_classification=run_classification,
-                    run_extraction=run_extraction,
-                )
+                create_price_tags_from_proof_prediction(proof, proof_prediction)
             return None
 
     if image is None:
@@ -874,12 +829,7 @@ def run_and_save_price_tag_detection(
             value=None,
             max_confidence=max_confidence,
         )
-        create_price_tags_from_proof_prediction(
-            proof,
-            proof_prediction,
-            run_classification=run_classification,
-            run_extraction=run_extraction,
-        )
+        create_price_tags_from_proof_prediction(proof, proof_prediction)
         return proof_prediction
     except Exception as e:
         logger.exception(e)

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -411,7 +411,7 @@ def proof_post_create_increment_counts(sender, instance, created, **kwargs):
 
 
 @receiver(signals.post_save, sender=Proof)
-def proof_post_save_run_ocr(sender, instance, created, **kwargs):
+def proof_post_create_run_ocr(sender, instance, created, **kwargs):
     if not settings.TESTING and settings.ENABLE_OCR:
         if created:
             async_task(
@@ -421,7 +421,7 @@ def proof_post_save_run_ocr(sender, instance, created, **kwargs):
 
 
 @receiver(signals.post_save, sender=Proof)
-def proof_post_save_run_ml_models(sender, instance, created, **kwargs):
+def proof_post_create_run_ml_models(sender, instance, created, **kwargs):
     """
     After saving a proof in DB, run ML models on it.
     - type prediction
@@ -750,18 +750,25 @@ def price_tag_post_save_generate_image(sender, instance, created, **kwargs):
 
 
 @receiver(signals.post_save, sender=PriceTag)
-def price_tag_post_save_run_ml_models(sender, instance, created, **kwargs):
+def price_tag_post_create_run_ml_models(sender, instance, created, **kwargs):
     """
     Run price tag ML models
     - only if created manually by a user
     - if created automatically from a proof prediction, the models will be run (in batch) in run_and_save_proof_prediction
     """
     if not settings.TESTING:
-        if created and instance.created_by:
+        if created:
             async_task(
                 "open_prices.proofs.ml.price_tags.run_and_save_price_tag_classification_from_id",
                 instance.id,
             )
+            # Price tag type prediction can have three possible values: "invalid",
+            # "medium-quality" and "high-quality".
+            # We used to only run the extraction model
+            # on price tags that are not predicted as "invalid" as there is nothing
+            # to extract on these image crops: either the price tag is too blurry or
+            # the crop is not actually a price tag.
+            # Now it is done in parallel.
             async_task(
                 "open_prices.proofs.ml.price_tags.run_and_save_price_tag_extraction_from_id",
                 instance.id,

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -865,9 +865,7 @@ class MLModelTest(TestCase):
             "open_prices.proofs.ml.price_tags.detect_price_tags",
             return_value=detect_price_tags_response,
         ):
-            result = run_and_save_price_tag_detection(
-                self.image, deleted_proof, run_extraction=False
-            )
+            result = run_and_save_price_tag_detection(self.image, deleted_proof)
             self.assertIsNone(result)
 
     def test_run_and_save_proof_prediction_for_receipt_proof(self):
@@ -901,8 +899,6 @@ class MLModelTest(TestCase):
                 ):
                     run_and_save_proof_prediction(
                         proof,
-                        run_price_tag_classification=False,
-                        run_price_tag_extraction=False,
                         run_receipt_extraction=False,
                     )
                     mock_predict_proof_type.assert_called_once()
@@ -997,8 +993,6 @@ class MLModelTest(TestCase):
                 ):
                     run_and_save_proof_prediction(
                         proof,
-                        run_price_tag_classification=True,
-                        run_price_tag_extraction=False,
                         run_receipt_extraction=False,
                     )
                     mock_predict_proof_type.assert_called_once()
@@ -1142,9 +1136,7 @@ class MLModelTest(TestCase):
                         ("high-quality", 0.01),
                     ],
                 ):
-                    result = run_and_save_price_tag_detection(
-                        self.image, proof, run_extraction=False
-                    )
+                    result = run_and_save_price_tag_detection(self.image, proof)
         self.assertIsNone(result)
         price_tags = PriceTag.objects.filter(proof=proof).all()
         self.assertEqual(len(price_tags), 2)
@@ -1200,7 +1192,7 @@ class MLModelTest(TestCase):
                     ],
                 ):
                     results = create_price_tags_from_proof_prediction(
-                        proof, proof_prediction, threshold=0.41, run_extraction=False
+                        proof, proof_prediction, threshold=0.41
                     )
         after = timezone.now()
         self.assertEqual(len(results), 2)


### PR DESCRIPTION
### What

Following #1345

Simplify `create_price_tags_from_proof_prediction`
- move `run_and_save_price_tag_classification` to PriceTag post_save signal
- move `run_and_save_price_tag_extraction` to PriceTag post_save signal
- (both were already there, just limited to manually drawn price tags)
