### PR TITLE
fix(Price Tags): Predictions: run extraction even if they are classified as invalid

### DIFF
--- a/open_prices/proofs/ml/price_tags.py
+++ b/open_prices/proofs/ml/price_tags.py
@@ -788,8 +788,9 @@ def create_price_tags_from_proof_prediction(
             # on price tags that are not predicted as "invalid" as there is nothing
             # to extract on these image crops: either the price tag is too blurry or
             # the crop is not actually a price tag.
-            if predicted_price_tag_type != "invalid":
-                to_process.append(price_tag_with_image)
+            # 2026-06-18: temporarily always run price tag extractions, even on price
+            # tags that are predicted as "invalid"
+            to_process.append(price_tag_with_image)
         else:
             # If we don't run classification, we run extraction on all detected price tags
             to_process.append(price_tag_with_image)

--- a/open_prices/proofs/ml/price_tags.py
+++ b/open_prices/proofs/ml/price_tags.py
@@ -779,9 +779,7 @@ def create_price_tags_from_proof_prediction(
             )
             if not classification:
                 continue
-            predicted_price_tag_type = classification.data.get("prediction", [{}])[
-                0
-            ].get("label")
+            classification.data.get("prediction", [{}])[0].get("label")
 
             # Price tag type prediction can have three possible values: "invalid",
             # "medium-quality" and "high-quality". We only run the extraction model
@@ -790,6 +788,7 @@ def create_price_tags_from_proof_prediction(
             # the crop is not actually a price tag.
             # 2026-06-18: temporarily always run price tag extractions, even on price
             # tags that are predicted as "invalid"
+            # if predicted_price_tag_type != "invalid":
             to_process.append(price_tag_with_image)
         else:
             # If we don't run classification, we run extraction on all detected price tags


### PR DESCRIPTION
The classifier wrongfully classified price tags of "raw products" as invalid, even when they're easy to read. We need to retrain the classifier with more example of these price tags, but in the meantime, let's run the extraction on all price tags.