### PR TITLE
chore(API): set the max page number queryable to 500

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -220,8 +220,8 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Open Prices API allows you to add product prices",
     "CONTACT": {
         "name": "The Open Food Facts team",
-        "url": f"{OPENFOODFACTS_URL}",
-        "email": f"{OPENFOODFACTS_EMAIL}",
+        "url": OPENFOODFACTS_URL,
+        "email": OPENFOODFACTS_EMAIL,
     },
     "LICENSE": {
         "name": " AGPL-3.0",

--- a/config/settings.py
+++ b/config/settings.py
@@ -2,6 +2,17 @@ import os
 import sys
 from pathlib import Path
 
+OPENFOODFACTS_URL = "https://world.openfoodfacts.org"
+OPENFOODFACTS_EMAIL = "contact@openfoodfacts.org"
+OPENPRICES_DOCS_URL = "https://openfoodfacts.github.io/open-prices/"
+OPENPRICES_DOCS_GUIDES_DATA_URL = (
+    "https://openfoodfacts.github.io/open-prices/guides/data/"
+)
+
+
+# Django config
+# ------------------------------------------------------------------------------
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -209,8 +220,8 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Open Prices API allows you to add product prices",
     "CONTACT": {
         "name": "The Open Food Facts team",
-        "url": "https://world.openfoodfacts.org",
-        "email": "contact@openfoodfacts.org",
+        "url": f"{OPENFOODFACTS_URL}",
+        "email": f"{OPENFOODFACTS_EMAIL}",
     },
     "LICENSE": {
         "name": " AGPL-3.0",

--- a/open_prices/api/challenges/tests.py
+++ b/open_prices/api/challenges/tests.py
@@ -28,8 +28,9 @@ class ChallengeListPaginationApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.url = reverse("api:challenges-list")
-        cls.challenge_1 = ChallengeFactory()
-        cls.challenge_2 = ChallengeFactory()
+        ChallengeFactory()
+        ChallengeFactory()
+        ChallengeFactory()
 
     def test_challenge_list_size(self):
         # default
@@ -37,6 +38,10 @@ class ChallengeListPaginationApiTest(TestCase):
         for PAGINATION_KEY in ["items", "page", "pages", "size", "total"]:
             with self.subTest(PAGINATION_KEY=PAGINATION_KEY):
                 self.assertIn(PAGINATION_KEY, response.data)
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(len(response.data["items"]), 3)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 1)
         self.assertEqual(response.data["size"], 10)  # default
 
 

--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -91,6 +91,10 @@ class LocationListPaginationApiTest(TestCase):
         for PAGINATION_KEY in ["items", "page", "pages", "size", "total"]:
             with self.subTest(PAGINATION_KEY=PAGINATION_KEY):
                 self.assertIn(PAGINATION_KEY, response.data)
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(len(response.data["items"]), 3)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 1)
         self.assertEqual(response.data["size"], 10)  # default
 
 

--- a/open_prices/api/moderation/tests.py
+++ b/open_prices/api/moderation/tests.py
@@ -79,6 +79,10 @@ class FlagListPaginationApiTest(TestCase):
         for PAGINATION_KEY in ["items", "page", "pages", "size", "total"]:
             with self.subTest(PAGINATION_KEY=PAGINATION_KEY):
                 self.assertIn(PAGINATION_KEY, response.data)
+        self.assertEqual(response.data["total"], 7)
+        self.assertEqual(len(response.data["items"]), 7)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 1)
         self.assertEqual(response.data["size"], 10)  # default
 
 

--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import ParseError
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
@@ -27,17 +27,17 @@ class CustomPagination(PageNumberPagination):
         Override the default get_page_number
 
         Custom rule:
-        - if the page number is greater than max_page_number, raise NotFound
+        - if the page number is greater than max_page_number, raise ParseError
         """
         page_number = super().get_page_number(request, paginator)
         try:
             page_number_int = int(page_number)
         except (TypeError, ValueError):
-            raise NotFound("Invalid page.") from None
+            raise ParseError("Invalid page.") from None
         if page_number_int < 1:
-            raise NotFound("Invalid page.")
+            raise ParseError("Invalid page.")
         if page_number_int > self.max_page_number:
-            raise NotFound(
+            raise ParseError(
                 f"Maximum page reached. See {settings.OPENPRICES_DOCS_GUIDES_DATA_URL} for alternate ways to access the data."
             )
         return page_number

--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -20,7 +20,7 @@ class CustomPagination(PageNumberPagination):
     ### page number config
     # page_query_param = "page"  # default
     last_page_strings = ()  # disable "last" page string
-    max_page_number = 1000  # custom rule, see get_page_number()
+    max_page_number = 500  # custom rule, see get_page_number()
 
     def get_page_number(self, request, paginator):
         """

--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -13,10 +13,12 @@ class CustomPagination(PageNumberPagination):
     - removed keys: next, previous
     """
 
+    ### page size config
     page_size = 10
-    page_size_query_param = "size"
+    page_size_query_param = "size"  # default is None
     max_page_size = 100
-    # page number rules
+    ### page number config
+    # page_query_param = "page"  # default
     last_page_strings = ()  # disable "last" page string
     max_page_number = 1000  # custom rule, see get_page_number()
 
@@ -28,7 +30,13 @@ class CustomPagination(PageNumberPagination):
         - if the page number is greater than max_page_number, raise NotFound
         """
         page_number = super().get_page_number(request, paginator)
-        if page_number > self.max_page_number:
+        try:
+            page_number_int = int(page_number)
+        except (TypeError, ValueError):
+            raise NotFound("Invalid page.") from None
+        if page_number_int < 1:
+            raise NotFound("Invalid page.")
+        if page_number_int > self.max_page_number:
             raise NotFound(
                 f"Maximum page reached. See {settings.OPENPRICES_DOCS_GUIDES_DATA_URL} for alternate ways to access the data."
             )

--- a/open_prices/api/pagination.py
+++ b/open_prices/api/pagination.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from rest_framework.exceptions import NotFound
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
@@ -14,6 +16,23 @@ class CustomPagination(PageNumberPagination):
     page_size = 10
     page_size_query_param = "size"
     max_page_size = 100
+    # page number rules
+    last_page_strings = ()  # disable "last" page string
+    max_page_number = 1000  # custom rule, see get_page_number()
+
+    def get_page_number(self, request, paginator):
+        """
+        Override the default get_page_number
+
+        Custom rule:
+        - if the page number is greater than max_page_number, raise NotFound
+        """
+        page_number = super().get_page_number(request, paginator)
+        if page_number > self.max_page_number:
+            raise NotFound(
+                f"Maximum page reached. See {settings.OPENPRICES_DOCS_GUIDES_DATA_URL} for alternate ways to access the data."
+            )
+        return page_number
 
     def get_paginated_response(self, data):
         return Response(

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -113,22 +113,6 @@ class PriceListPaginationApiTest(TestCase):
         self.assertEqual(response.data["page"], 1)
         self.assertEqual(response.data["pages"], 1)
         self.assertEqual(response.data["size"], 10)  # default
-        # size=150
-        url = self.url + "?size=150"
-        response = self.client.get(url)
-        self.assertEqual(response.data["total"], 3)
-        self.assertEqual(len(response.data["items"]), 3)
-        self.assertEqual(response.data["page"], 1)
-        self.assertEqual(response.data["pages"], 1)
-        self.assertEqual(response.data["size"], 100)  # max to 100
-        # size=1
-        url = self.url + "?size=1"
-        response = self.client.get(url)
-        self.assertEqual(response.data["total"], 3)
-        self.assertEqual(len(response.data["items"]), 1)
-        self.assertEqual(response.data["page"], 1)
-        self.assertEqual(response.data["pages"], 3)
-        self.assertEqual(response.data["size"], 1)
 
 
 class PriceListOrderApiTest(TestCase):

--- a/open_prices/api/products/tests.py
+++ b/open_prices/api/products/tests.py
@@ -45,6 +45,10 @@ class ProductListPaginationApiTest(TestCase):
         for PAGINATION_KEY in ["items", "page", "pages", "size", "total"]:
             with self.subTest(PAGINATION_KEY=PAGINATION_KEY):
                 self.assertIn(PAGINATION_KEY, response.data)
+        self.assertEqual(response.data["total"], 3)
+        self.assertEqual(len(response.data["items"]), 3)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 1)
         self.assertEqual(response.data["size"], 10)  # default
 
 

--- a/open_prices/api/tests.py
+++ b/open_prices/api/tests.py
@@ -1,8 +1,11 @@
 import base64
 
+from django.db.models.signals import post_save
 from django.test import TestCase
 from django.urls import reverse
+from factory.django import mute_signals
 
+from open_prices.prices.factories import PriceFactory
 from open_prices.users.factories import SessionFactory
 
 
@@ -23,3 +26,77 @@ class StatusTest(TestCase):
                 response = self.client.get(self.url, headers=HEADERS_OK)
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.json(), {"status": "running"})
+
+
+class PaginationTest(TestCase):
+    """
+    There are already *PaginationApiTest in the different API test files.
+    Here we add more tests for our custom pagination class.
+    We'll run these tests on the Price list endpoint.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        with mute_signals(post_save):
+            PriceFactory.create_batch(1001)
+        cls.url = reverse("api:prices-list")
+
+    def test_pagination_size(self):
+        # default
+        response = self.client.get(self.url)
+        for pagination_key in ["items", "page", "pages", "size", "total"]:
+            with self.subTest(pagination_key=pagination_key):
+                self.assertIn(pagination_key, response.data)
+        self.assertEqual(response.data["total"], 1001)
+        self.assertEqual(len(response.data["items"]), 10)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 101)
+        self.assertEqual(response.data["size"], 10)  # default
+        # size=150
+        url = self.url + "?size=150"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1001)
+        self.assertEqual(len(response.data["items"]), 100)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 11)
+        self.assertEqual(response.data["size"], 100)  # max to 100
+        # size=1
+        url = self.url + "?size=1"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1001)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 1001)
+        self.assertEqual(response.data["size"], 1)
+
+    def test_pagination_page_number(self):
+        # default
+        response = self.client.get(self.url)
+        self.assertEqual(response.data["page"], 1)
+        # page=1
+        url = self.url + "?page=1"
+        response = self.client.get(url)
+        self.assertEqual(response.data["page"], 1)
+        # page=2
+        url = self.url + "?page=2"
+        response = self.client.get(url)
+        self.assertEqual(response.data["page"], 2)
+        # size=1 & page=1000
+        url = self.url + "?size=1&page=1000"
+        response = self.client.get(url)
+        self.assertEqual(response.data["page"], 1000)
+        # size=1 & page=1001
+        url = self.url + "?size=1&page=1001"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("Maximum page reached", response.json()["detail"])
+        # page=last
+        url = self.url + "?page=last"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("Invalid page", response.json()["detail"])
+        # page=0
+        url = self.url + "?page=0"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("Invalid page", response.json()["detail"])

--- a/open_prices/api/tests.py
+++ b/open_prices/api/tests.py
@@ -38,7 +38,7 @@ class PaginationTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         with mute_signals(post_save):
-            PriceFactory.create_batch(1001)
+            PriceFactory.create_batch(1000)
         cls.url = reverse("api:prices-list")
 
     def test_pagination_size(self):
@@ -47,53 +47,81 @@ class PaginationTest(TestCase):
         for pagination_key in ["items", "page", "pages", "size", "total"]:
             with self.subTest(pagination_key=pagination_key):
                 self.assertIn(pagination_key, response.data)
-        self.assertEqual(response.data["total"], 1001)
+        self.assertEqual(response.data["total"], 1000)
         self.assertEqual(len(response.data["items"]), 10)
         self.assertEqual(response.data["page"], 1)
-        self.assertEqual(response.data["pages"], 101)
+        self.assertEqual(response.data["pages"], 100)
         self.assertEqual(response.data["size"], 10)  # default
         # size=150
         url = self.url + "?size=150"
         response = self.client.get(url)
-        self.assertEqual(response.data["total"], 1001)
-        self.assertEqual(len(response.data["items"]), 100)
+        self.assertEqual(response.data["total"], 1000)
+        self.assertEqual(len(response.data["items"]), 100)  # max to 100
         self.assertEqual(response.data["page"], 1)
-        self.assertEqual(response.data["pages"], 11)
+        self.assertEqual(response.data["pages"], 10)
         self.assertEqual(response.data["size"], 100)  # max to 100
         # size=1
         url = self.url + "?size=1"
         response = self.client.get(url)
-        self.assertEqual(response.data["total"], 1001)
+        self.assertEqual(response.data["total"], 1000)
         self.assertEqual(len(response.data["items"]), 1)
         self.assertEqual(response.data["page"], 1)
-        self.assertEqual(response.data["pages"], 1001)
+        self.assertEqual(response.data["pages"], 1000)
         self.assertEqual(response.data["size"], 1)
 
     def test_pagination_page_number(self):
-        # default
+        # size=1 & page=1
+        url = self.url + "?size=1&page=1"
+        response = self.client.get(url)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 1000)
+        # size=1 & page=500
+        url = self.url + "?size=1&page=500"
+        response = self.client.get(url)
+        self.assertEqual(response.data["page"], 500)
+        self.assertEqual(response.data["pages"], 1000)
+        # size=1 & page=501
+        url = self.url + "?size=1&page=501"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)  # max page is 500
+        self.assertIn("Maximum page reached", response.json()["detail"])
+        # size=10 & page=1 (default)
         response = self.client.get(self.url)
         self.assertEqual(response.data["page"], 1)
-        # page=1
+        self.assertEqual(response.data["pages"], 100)
+        # size=10 & page=1
         url = self.url + "?page=1"
         response = self.client.get(url)
         self.assertEqual(response.data["page"], 1)
-        # page=2
+        self.assertEqual(response.data["pages"], 100)
+        # size=10 & page=2
         url = self.url + "?page=2"
         response = self.client.get(url)
         self.assertEqual(response.data["page"], 2)
-        # size=100 & page=100
-        url = self.url + "?size=100&page=100"
+        self.assertEqual(response.data["pages"], 100)
+        # size=10 & page=100
+        url = self.url + "?page=100"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)  # last page is 11
-        # size=1 & page=1000
-        url = self.url + "?size=1&page=1000"
+        self.assertEqual(response.data["page"], 100)
+        self.assertEqual(response.data["pages"], 100)
+        # size=10 & page=101
+        url = self.url + "?page=101"
         response = self.client.get(url)
-        self.assertEqual(response.data["page"], 1000)
-        # size=1 & page=1001
-        url = self.url + "?size=1&page=1001"
+        self.assertEqual(response.status_code, 404)  # last page is 100
+        # size=100 & page=1
+        url = self.url + "?size=100&page=1"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 400)  # max page is 1000
-        self.assertIn("Maximum page reached", response.json()["detail"])
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 10)
+        # size=100 & page=10
+        url = self.url + "?size=100&page=10"
+        response = self.client.get(url)
+        self.assertEqual(response.data["page"], 10)
+        self.assertEqual(response.data["pages"], 10)
+        # size=100 & page=11
+        url = self.url + "?size=100&page=11"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)  # last page is 10
         # page=last
         url = self.url + "?page=last"
         response = self.client.get(url)

--- a/open_prices/api/tests.py
+++ b/open_prices/api/tests.py
@@ -81,6 +81,10 @@ class PaginationTest(TestCase):
         url = self.url + "?page=2"
         response = self.client.get(url)
         self.assertEqual(response.data["page"], 2)
+        # size=100 & page=100
+        url = self.url + "?size=100&page=100"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)  # last page is 11
         # size=1 & page=1000
         url = self.url + "?size=1&page=1000"
         response = self.client.get(url)
@@ -88,15 +92,15 @@ class PaginationTest(TestCase):
         # size=1 & page=1001
         url = self.url + "?size=1&page=1001"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)  # max page is 1000
         self.assertIn("Maximum page reached", response.json()["detail"])
         # page=last
         url = self.url + "?page=last"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)  # last page string is disabled
         self.assertIn("Invalid page", response.json()["detail"])
         # page=0
         url = self.url + "?page=0"
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)  # invalid page number
         self.assertIn("Invalid page", response.json()["detail"])


### PR DESCRIPTION
### What

Improve our CustomPagination
- new `max_page_number` set to 500
  - f the page 501 is asked, it will return a 400 with a message (link to the docs [Guides > Data](https://openfoodfacts.github.io/open-prices/guides/data/)).
- also disable the `page=last` default behavior
  - return a 400 with a message ("Invalid page")

Add tests.

### Why

Reduce scraping.
