### PR TITLE
fix(Admin): Proofs: fix display of images (following #1350)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Directory where user-uploaded images are stored
 IMAGES_DIR = BASE_DIR / "img"
+# for URL generation
+IMAGES_DIR_DISPLAY = Path("/img")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/

--- a/open_prices/proofs/admin.py
+++ b/open_prices/proofs/admin.py
@@ -85,9 +85,9 @@ class PriceTagAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
 
     @admin.display(description="Image")
     def image_display(self, price_tag):
-        if price_tag.image_path_full:
+        if price_tag.image_path_display:
             return mark_safe(
-                f'<img src="{price_tag.image_path_full}" title="{price_tag.image_path_full}" />'  # noqa
+                f'<img src="{price_tag.image_path_display}" title="{price_tag.image_path_display}" height="300" />'  # noqa
             )
         else:
             return mark_safe("<div>-</div>")
@@ -208,8 +208,8 @@ class ProofAdmin(admin.ModelAdmin):
     def image_display(self, proof):
         if proof.image_thumb_path:
             return mark_safe(
-                f'<a href="{proof.file_path_full}" target="_blank">'
-                f'<img src="{proof.image_thumb_path_full}" title="{proof.image_thumb_path_full}" />'  # noqa
+                f'<a href="{proof.file_path_display}" target="_blank">'
+                f'<img src="{proof.image_thumb_path_display}" title="{proof.image_thumb_path_display}" height="300" />'  # noqa
                 f"</a>"
             )
         else:

--- a/open_prices/proofs/models.py
+++ b/open_prices/proofs/models.py
@@ -304,9 +304,21 @@ class Proof(models.Model):
         super().save(*args, **kwargs)
 
     @property
+    def file_path_display(self):
+        if self.file_path:
+            return str(settings.IMAGES_DIR_DISPLAY / self.file_path)
+        return None
+
+    @property
     def file_path_full(self):
         if self.file_path:
             return str(settings.IMAGES_DIR / self.file_path)
+        return None
+
+    @property
+    def image_thumb_path_display(self):
+        if self.image_thumb_path:
+            return str(settings.IMAGES_DIR_DISPLAY / self.image_thumb_path)
         return None
 
     @property
@@ -650,6 +662,10 @@ class PriceTag(models.Model):
         from open_prices.proofs.utils import get_price_tag_image_path
 
         return get_price_tag_image_path(self.id)
+
+    @property
+    def image_path_display(self):
+        return str(settings.IMAGES_DIR_DISPLAY / self.image_path)
 
     @property
     def image_path_full(self):


### PR DESCRIPTION
### What

Following #1350
Image path were incorrectly generated (storage path vs display path)

Fix by having a dedicated `settings.IMAGES_DIR_DISPLAY`

### Screenshot

|Before|After|
|-|-|
|<img width="369" height="220" alt="image" src="https://github.com/user-attachments/assets/e0eab4de-c027-4578-8f78-5b8a49ba55d5" />|<img width="777" height="527" alt="image" src="https://github.com/user-attachments/assets/211e8d4c-3434-49c2-b5d8-69ac6eb4586a" />|
