### PR TITLE
refactor(API): Proofs: add tags__not_contains filter for proofs & price tags

### DIFF
--- a/open_prices/api/proofs/filters.py
+++ b/open_prices/api/proofs/filters.py
@@ -24,6 +24,9 @@ class ProofFilter(django_filters.FilterSet):
         choices=location_constants.TYPE_CHOICES,
     )
     tags__contains = django_filters.CharFilter(field_name="tags", lookup_expr="any")
+    tags__not_contains = django_filters.CharFilter(
+        field_name="tags", lookup_expr="any", exclude=True
+    )
 
     def filter_kind(self, queryset, name, value):
         if value == constants.KIND_COMMUNITY:
@@ -60,6 +63,9 @@ class PriceTagFilter(django_filters.FilterSet):
         field_name="price_count", lookup_expr="lte"
     )
     tags__contains = django_filters.CharFilter(field_name="tags", lookup_expr="any")
+    tags__not_contains = django_filters.CharFilter(
+        field_name="tags", lookup_expr="any", exclude=True
+    )
     created__gte = django_filters.DateTimeFilter(
         field_name="created", lookup_expr="gte"
     )

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -284,11 +284,15 @@ class ProofListFilterApiTest(TestCase):
 
     def test_proof_list_filter_by_tags(self):
         self.assertEqual(Proof.objects.count(), 3)
-        # tags
+        # tags__contains
         url = self.url + "?tags__contains=challenge-1"
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 1)
         self.assertEqual(response.data["items"][0]["tags"], ["challenge-1"])
+        # tags__not_contains
+        url = self.url + "?tags__not_contains=challenge-1"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 2)
 
     def test_proof_list_filter_by_owner(self):
         self.assertEqual(Proof.objects.count(), 3)
@@ -1107,7 +1111,9 @@ class PriceTagListApiTest(TestCase):
         )
         cls.price_tag_2 = PriceTagFactory(proof=cls.proof)
         cls.price_tag_3 = PriceTagFactory(
-            proof=cls.proof_2, status=proof_constants.PriceTagStatus.deleted
+            proof=cls.proof_2,
+            tags=["invalid"],
+            status=proof_constants.PriceTagStatus.deleted,
         )
 
     def test_price_tag_list(self):
@@ -1177,13 +1183,18 @@ class PriceTagListApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 2)
 
-    def test_price_list_filter_by_tags(self):
+    def test_price_tag_list_filter_by_tags(self):
+        # tags__contains
         url = self.url + "?tags__contains=prediction-found-product"
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 1)
         self.assertEqual(
             response.data["items"][0]["tags"], ["prediction-found-product"]
         )
+        # tags__not_contains
+        url = self.url + "?tags__not_contains=invalid"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 2)
 
 
 class PriceTagDetailApiTest(TestCase):


### PR DESCRIPTION
### What

Following #1354
This will be useful for the frontend and filter in/out price tags set as invalid.
Currently we're filtering on the prediction_count but it was a hack

