### PR TITLE
refactor(Tasks): move logic to model classmethods. so that they can be called elsewhere (e.g. tests)

### DIFF
--- a/open_prices/api/users/tests.py
+++ b/open_prices/api/users/tests.py
@@ -141,7 +141,7 @@ class UserBadgeListApiTest(TestCase):
 
     def test_user_badges_list(self):
         # Update user badges and count
-        Badge.update_badge_task()
+        Badge.update_task()
         self.user.refresh_from_db()
         user_badge = self.user.user_badges.first()
 
@@ -160,7 +160,7 @@ class UserBadgeListApiTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        Badge.update_badge_task()
+        Badge.update_task()
         self.user.refresh_from_db()
 
         response = self.client.get(self.url)
@@ -173,7 +173,7 @@ class UserBadgeListApiTest(TestCase):
         BadgeFactory(metric="price_count", threshold=20)
 
         # Update user badges and count
-        Badge.update_badge_task()
+        Badge.update_task()
         self.user.refresh_from_db()
 
         response = self.client.get(self.url)

--- a/open_prices/api/users/tests.py
+++ b/open_prices/api/users/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from open_prices.badges.factories import BadgeFactory
+from open_prices.badges.models import Badge
 from open_prices.users.factories import SessionFactory, UserFactory
 from open_prices.users.models import User
 
@@ -140,7 +141,7 @@ class UserBadgeListApiTest(TestCase):
 
     def test_user_badges_list(self):
         # Update user badges and count
-        self.badge.update_user_badges()
+        Badge.update_badge_task()
         self.user.refresh_from_db()
         user_badge = self.user.user_badges.first()
 
@@ -159,7 +160,7 @@ class UserBadgeListApiTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        self.badge.update_user_badges()
+        Badge.update_badge_task()
         self.user.refresh_from_db()
 
         response = self.client.get(self.url)
@@ -169,11 +170,10 @@ class UserBadgeListApiTest(TestCase):
 
     def test_user_badges_list_only_returns_achieved_badges(self):
         # Create a badge that the user has not achieved
-        unachieved_badge = BadgeFactory(metric="price_count", threshold=20)
+        BadgeFactory(metric="price_count", threshold=20)
 
         # Update user badges and count
-        self.badge.update_user_badges()
-        unachieved_badge.update_user_badges()
+        Badge.update_badge_task()
         self.user.refresh_from_db()
 
         response = self.client.get(self.url)

--- a/open_prices/badges/models.py
+++ b/open_prices/badges/models.py
@@ -29,6 +29,16 @@ class Badge(models.Model):
     def __str__(self):
         return self.name
 
+    @classmethod
+    def update_badge_task(cls):
+        """
+        1. Give badges to users based on their count fields
+        2. Update badge field counts
+        """
+        for badge in cls.objects.all():
+            badge.update_user_badges()
+            badge.update_user_count()
+
     def user_has_achieved(self, user: User) -> bool:
         """
         Examples:

--- a/open_prices/badges/models.py
+++ b/open_prices/badges/models.py
@@ -30,7 +30,7 @@ class Badge(models.Model):
         return self.name
 
     @classmethod
-    def update_badge_task(cls):
+    def update_task(cls):
         """
         1. Give badges to users based on their count fields
         2. Update badge field counts

--- a/open_prices/badges/tests.py
+++ b/open_prices/badges/tests.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from open_prices.badges import constants as badge_constants
 from open_prices.badges.factories import BadgeFactory
-from open_prices.badges.models import UserBadge
+from open_prices.badges.models import Badge, UserBadge
 from open_prices.users.factories import UserFactory
 
 
@@ -51,8 +51,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        self.badge.update_user_badges()
-        self.badge.update_user_count()
+        Badge.update_badge_task()
         self.badge.refresh_from_db()
 
         # Stats should be updated correctly
@@ -70,16 +69,14 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        self.badge.update_user_badges()
-        self.badge.update_user_count()
+        Badge.update_badge_task()
         self.badge.refresh_from_db()
         user_badge_achieved_at = UserBadge.objects.get(
             user=self.user, badge=self.badge
         ).achieved_at
 
         # Update user badges and count again
-        self.badge.update_user_badges()
-        self.badge.update_user_count()
+        Badge.update_badge_task()
         self.badge.refresh_from_db()
 
         # user_badge_achieved_at is unchanged
@@ -97,10 +94,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        self.badge.update_user_badges()
-        self.badge.update_user_count()
-        badge_2.update_user_badges()
-        badge_2.update_user_count()
+        Badge.update_badge_task()
         self.badge.refresh_from_db()
         badge_2.refresh_from_db()
 
@@ -117,8 +111,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        self.badge.update_user_badges()
-        self.badge.update_user_count()
+        Badge.update_badge_task()
         self.badge.refresh_from_db()
         user_badge_achieved_at = UserBadge.objects.get(
             user=self.user, badge=self.badge
@@ -129,8 +122,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count again
-        self.badge.update_user_badges()
-        self.badge.update_user_count()
+        Badge.update_badge_task()
         self.badge.refresh_from_db()
 
         # The badge should still be present for the user

--- a/open_prices/badges/tests.py
+++ b/open_prices/badges/tests.py
@@ -51,7 +51,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        Badge.update_badge_task()
+        Badge.update_task()
         self.badge.refresh_from_db()
 
         # Stats should be updated correctly
@@ -69,14 +69,14 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        Badge.update_badge_task()
+        Badge.update_task()
         self.badge.refresh_from_db()
         user_badge_achieved_at = UserBadge.objects.get(
             user=self.user, badge=self.badge
         ).achieved_at
 
         # Update user badges and count again
-        Badge.update_badge_task()
+        Badge.update_task()
         self.badge.refresh_from_db()
 
         # user_badge_achieved_at is unchanged
@@ -94,7 +94,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        Badge.update_badge_task()
+        Badge.update_task()
         self.badge.refresh_from_db()
         badge_2.refresh_from_db()
 
@@ -111,7 +111,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count
-        Badge.update_badge_task()
+        Badge.update_task()
         self.badge.refresh_from_db()
         user_badge_achieved_at = UserBadge.objects.get(
             user=self.user, badge=self.badge
@@ -122,7 +122,7 @@ class BadgePropertyTest(TestCase):
         self.user.save()
 
         # Update user badges and count again
-        Badge.update_badge_task()
+        Badge.update_task()
         self.badge.refresh_from_db()
 
         # The badge should still be present for the user

--- a/open_prices/challenges/models.py
+++ b/open_prices/challenges/models.py
@@ -54,7 +54,7 @@ class ChallengeQuerySet(models.QuerySet):
             status_annotated=challenge_constants.CHALLENGE_STATUS_ONGOING
         )
 
-    def to_update_in_daily_task(self):
+    def for_update_task(self):
         """
         Goal: Choose which challenges stats we want to update.
         - Data updated? categories_full, price/proof tags, stats
@@ -136,6 +136,18 @@ class Challenge(models.Model):
         """
         self.full_clean()
         super().save(*args, **kwargs)
+
+    @classmethod
+    def update_task(cls):
+        """
+        - Update challenge categories_full, price/proof tags, stats
+        - Some challenges are skipped (see queryset)
+        """
+        for challenge in cls.objects.for_update_task():
+            challenge.calculate_categories_full()
+            challenge.set_price_tags()  # will only apply on 'ONGOING' challenges
+            challenge.set_proof_tags()  # will only apply based on price 'challenge' tags
+            challenge.calculate_stats()
 
     @property
     def start_date_with_time(self):

--- a/open_prices/challenges/tests.py
+++ b/open_prices/challenges/tests.py
@@ -194,20 +194,20 @@ class ChallengeStatusQuerySetAndPropertyTest(TestCase):
         self.assertEqual(Challenge.objects.count(), 4)
         self.assertEqual(Challenge.objects.is_ongoing().count(), 1)
 
-    def test_challenge_to_update_in_daily_task_queryset(self):
+    def test_challenge_for_update_task_queryset(self):
         self.assertEqual(Challenge.objects.count(), 4)
         with freeze_time("2024-06-15"):
             # challenge_completed hasn't started yet
-            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 4)
+            self.assertEqual(Challenge.objects.for_update_task().count(), 4)
         with freeze_time("2024-07-15"):
             # challenge_completed is ongoing
-            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 4)
+            self.assertEqual(Challenge.objects.for_update_task().count(), 4)
         with freeze_time("2024-07-31"):
             # challenge_completed has been over for less than X days
-            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 4)
+            self.assertEqual(Challenge.objects.for_update_task().count(), 4)
         with freeze_time("2025-01-01"):
             # challenge_completed has been over for more than X days
-            self.assertEqual(Challenge.objects.to_update_in_daily_task().count(), 3)
+            self.assertEqual(Challenge.objects.for_update_task().count(), 3)
 
 
 class ChallengePropertyTest(TestCase):

--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -58,54 +58,27 @@ def import_all_product_db_task():
 
 
 def update_total_stats_task():
-    """
-    Update all total stats
-    """
-    total_stats = TotalStats.get_solo()
-    total_stats.update_price_stats()
-    total_stats.update_product_stats()
-    total_stats.update_location_stats()
-    total_stats.update_proof_stats()
-    total_stats.update_price_tag_stats()
-    total_stats.update_user_stats()
-    total_stats.update_challenge_stats()
-    total_stats.update_product_created_stats()
+    TotalStats.update_task()
 
 
 def update_product_counts_task():
-    """
-    Update product field counts
-    """
-    for product in Product.objects.to_update_in_counts_task():
-        product.update_price_count()
-        product.update_location_count()
-        product.update_user_count()
-        product.update_proof_count()
+    Product.update_task()
 
 
 def update_user_counts_task():
-    """
-    Update user field counts
-    """
-    for user in User.objects.all():
-        user.update_price_count()
-        user.update_location_count()
-        user.update_product_count()
-        user.update_proof_count()
-        user.update_other_count()
+    User.update_task()
 
 
 def update_location_counts_task():
-    """
-    Update location field counts
-    """
-    for location in Location.objects.all():
-        for field in Location.COUNT_FIELDS:
-            getattr(location, f"update_{field}")()
+    Location.update_task()
+
+
+def update_challenge_task():
+    Challenge.update_task()
 
 
 def update_badge_task():
-    Badge.update_badge_task()
+    Badge.update_task()
 
 
 def fix_proof_fields_task():
@@ -122,14 +95,6 @@ def fix_proof_fields_task():
 def moderation_tasks():
     moderation_rules.cleanup_products_with_long_barcodes()
     moderation_rules.cleanup_products_with_invalid_barcodes()
-
-
-def challenge_tasks():
-    for challenge in Challenge.objects.to_update_in_daily_task():
-        challenge.calculate_categories_full()
-        challenge.set_price_tags()  # will only apply on 'ONGOING' challenges
-        challenge.set_proof_tags()  # will only apply based on price 'challenge' tags
-        challenge.calculate_stats()
 
 
 def dump_db_task():
@@ -168,7 +133,7 @@ CRON_SCHEDULES = {
     "update_total_stats_task": ("0 1 * * *", {}),  # daily at 01:00
     "fix_proof_fields_task": ("10 1 * * *", {}),  # daily at 01:10
     "moderation_tasks": ("20 1 * * *", {}),  # daily at 01:20
-    "challenge_tasks": ("30 1 * * *", {}),  # daily at 01:30
+    "update_challenge_task": ("30 1 * * *", {}),  # daily at 01:30
     "history_cleanup_task": ("0 3 * * 1", {}),  # daily at 03:00
     "proof_draft_cleanup_task": ("*/5 * * * *", {}),  # every 5 minutes
     "update_user_counts_task": ("0 2 * * 1", {}),  # daily at 02:00

--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -105,13 +105,7 @@ def update_location_counts_task():
 
 
 def update_badge_task():
-    """
-    1. Give badges to users based on their count fields
-    2. Update badge field counts
-    """
-    for badge in Badge.objects.all():
-        badge.update_user_badges()
-        badge.update_user_count()
+    Badge.update_badge_task()
 
 
 def fix_proof_fields_task():

--- a/open_prices/locations/models.py
+++ b/open_prices/locations/models.py
@@ -229,6 +229,17 @@ class Location(models.Model):
         self.full_clean()
         super().save(*args, **kwargs)
 
+    @classmethod
+    def update_task(cls):
+        """
+        - Update location field counts
+        """
+        for location in cls.objects.all():
+            location.update_price_count()
+            location.update_user_count()
+            location.update_product_count()
+            location.update_proof_count()
+
     @property
     def is_type_osm(self):
         return self.type == location_constants.TYPE_OSM

--- a/open_prices/products/models.py
+++ b/open_prices/products/models.py
@@ -47,7 +47,7 @@ class ProductQuerySet(ApproximateCountQuerySet):
             )
         return queryset
 
-    def to_update_in_counts_task(self):
+    def for_update_task(self):
         """
         Goal: only update counts of products that have prices, to save (some) time.
         We use the annotated price_count instead of the denormalized price_count field to be sure to have up-to-date information.
@@ -182,6 +182,18 @@ class Product(models.Model):
         self.normalize_code()
         self.full_clean()
         super().save(*args, **kwargs)
+
+    @classmethod
+    def update_task(cls):
+        """
+        - Update product field counts
+        - Some products are skipped (see queryset)
+        """
+        for product in cls.objects.for_update_task():
+            product.update_price_count()
+            product.update_location_count()
+            product.update_user_count()
+            product.update_proof_count()
 
     def price__min(self, exclude_discounted=False):
         if exclude_discounted:

--- a/open_prices/stats/models.py
+++ b/open_prices/stats/models.py
@@ -147,6 +147,21 @@ class TotalStats(SingletonModel):
     class Meta:
         verbose_name = "Total Stats"
 
+    @classmethod
+    def update_task(cls):
+        """
+        Update all total stats
+        """
+        total_stats = cls.get_solo()
+        total_stats.update_price_stats()
+        total_stats.update_product_stats()
+        total_stats.update_location_stats()
+        total_stats.update_proof_stats()
+        total_stats.update_price_tag_stats()
+        total_stats.update_user_stats()
+        total_stats.update_challenge_stats()
+        total_stats.update_product_created_stats()
+
     def update_price_stats(self):
         from open_prices.prices.models import Price
 

--- a/open_prices/users/models.py
+++ b/open_prices/users/models.py
@@ -81,6 +81,18 @@ class User(models.Model):
         verbose_name = "User"
         verbose_name_plural = "Users"
 
+    @classmethod
+    def update_task(cls):
+        """
+        - Update user field counts
+        """
+        for user in cls.objects.all():
+            user.update_price_count()
+            user.update_location_count()
+            user.update_product_count()
+            user.update_proof_count()
+            user.update_other_count()
+
     def is_authenticated(self):
         return True
 


### PR DESCRIPTION
### What

When doing #1362 I had issues calling the `update_badge_task` from the `tasks.py`.
Recommended way is to move the logic to the `Badge` model as a classmethod.

Did this for all models that needed it
- TotalStats
- Product
- User
- Location
- Challenge
- Badge
