### PR TITLE
feat: add new route to anonymize receipt

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -196,7 +196,7 @@ CORS_ALLOW_CREDENTIALS = True
 # https://pillow.readthedocs.io/
 # ------------------------------------------------------------------------------
 
-THUMBNAIL_SIZE = (400, 400)
+THUMBNAIL_SIZE = 400
 
 
 # Django REST Framework (DRF) & django-filters & drf-spectacular

--- a/open_prices/api/proofs/serializers.py
+++ b/open_prices/api/proofs/serializers.py
@@ -76,6 +76,32 @@ class ProofDraftUploadSerializer(serializers.ModelSerializer):
         fields = ["file", "type"]
 
 
+class DraftProofAnonymizeRequestSerializer(serializers.Serializer):
+    """Serializer for payload when anonymizing a receipt."""
+
+    bounding_boxes = serializers.ListField(
+        child=serializers.ListField(
+            child=serializers.FloatField(),
+            min_length=4,
+            max_length=4,
+        ),
+        min_length=1,
+    )
+
+    def validate_bounding_boxes(self, value):
+        for bounding_box in value:
+            x_min, y_min, x_max, y_max = bounding_box
+            if x_min >= x_max or y_min >= y_max:
+                raise serializers.ValidationError(
+                    "Bounding box coordinates are invalid"
+                )
+            if x_min < 0 or y_min < 0 or x_max > 1 or y_max > 1:
+                raise serializers.ValidationError(
+                    "Bounding box coordinates are out of bounds"
+                )
+        return value
+
+
 class ProofCreateSerializer(serializers.ModelSerializer):
     location_id = serializers.PrimaryKeyRelatedField(
         queryset=Location.objects.all(), source="location", required=False

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -1,10 +1,15 @@
 import os
 import shutil
+import tempfile
 from decimal import Decimal
 from io import BytesIO
+from pathlib import Path
 
+import cv2
+import numpy as np
 from django.conf import settings
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 from PIL import Image
 
@@ -1080,6 +1085,107 @@ class ProofDraftDeleteApiTest(TestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(response.data, None)
         self.assertEqual(Proof.objects.filter(id=self.user_1_draft_proof.id).count(), 0)
+
+
+class ProofDraftAnonymizeApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.session = SessionFactory()
+        cls.price_tag_draft_proof = ProofFactory(
+            draft=True,
+            owner=cls.session.user.user_id,
+            type=proof_constants.TYPE_PRICE_TAG,
+        )
+        cls.receipt_non_draft_proof = ProofFactory(
+            draft=False,
+            owner=cls.session.user.user_id,
+            type=proof_constants.TYPE_RECEIPT,
+        )
+
+    def test_anonymize_draft_price_tag_error(self):
+        """Check that price tags cannot be anonymized."""
+        url = reverse(
+            "api:proofs-drafts-anonymize-receipt", args=[self.price_tag_draft_proof.id]
+        )
+        response = self.client.post(
+            url, headers={"Authorization": f"Bearer {self.session.token}"}
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("detail", response.data)
+        self.assertEqual(response.data["detail"], "Only receipts can be anonymized")
+
+    def test_anonymize_non_draft_receipt_error(self):
+        """Check that receipt proofs that are not draft cannot be anonymized."""
+        url = reverse(
+            "api:proofs-drafts-anonymize-receipt",
+            args=[self.receipt_non_draft_proof.id],
+        )
+        response = self.client.post(
+            url, headers={"Authorization": f"Bearer {self.session.token}"}
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("detail", response.data)
+        self.assertEqual(response.data["detail"], "No Proof matches the given query.")
+
+    @override_settings(IMAGES_DIR=Path(tempfile.mkdtemp()))
+    def test_anonymize_draft_receipt(self):
+        """Check the anonymized version of the receipt is saved on disk."""
+
+        tmp_dir = settings.IMAGES_DIR
+        proof_dir = tmp_dir / "0001"
+        proof_dir.mkdir(parents=True, exist_ok=True)
+        image_path = proof_dir / "1.jpg"
+        image_thumb_path = proof_dir / "1.400.jpg"
+        image = np.ones((1000, 1000, 3), dtype=np.uint8) * 255
+        image_thumb = cv2.resize(image, (400, 400))
+        cv2.imwrite(str(image_path), image)
+        cv2.imwrite(str(image_thumb_path), image_thumb)
+
+        receipt_draft_proof = ProofFactory(
+            file_path=str(image_path),
+            image_thumb_path=image_thumb_path,
+            draft=True,
+            owner=self.session.user.user_id,
+            type=proof_constants.TYPE_RECEIPT,
+        )
+        url = reverse(
+            "api:proofs-drafts-anonymize-receipt",
+            args=[receipt_draft_proof.id],
+        )
+        bounding_boxes = [
+            [0.1, 0.6, 0.15, 0.65],
+            [0.4, 0.1, 0.45, 0.15],
+        ]
+        response = self.client.post(
+            url,
+            data={"bounding_boxes": bounding_boxes},
+            headers={"Authorization": f"Bearer {self.session.token}"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # We uploaded a JPEG image, check that it's not on disk anymore (converted to WEBP)
+        self.assertFalse(image_path.exists())
+        self.assertFalse(image_thumb_path.exists())
+
+        image_path = image_path.with_suffix(".webp")
+        image_thumb_path = image_thumb_path.with_suffix(".webp")
+        image = cv2.imread(str(image_path))
+        image_thumb = cv2.imread(str(image_thumb_path))
+        # Check that the images were anonymized
+        self.assertIsNotNone(image)
+        self.assertIsNotNone(image_thumb)
+        self.assertEqual(image.shape, (1000, 1000, 3))
+        self.assertEqual(image_thumb.shape, (400, 400, 3))
+        # Check that the areas corresponding to the bounding boxes
+        # are in black color now
+        self.assertEqual(image[600:650, 100:150].sum(), 0)
+        self.assertEqual(image[100:150, 400:450].sum(), 0)
+
+        # Retrieve the proof from DB
+        proof = Proof.all_objects.get(id=receipt_draft_proof.id)
+        self.assertEqual(proof.file_path, "0001/1.webp")
+        self.assertEqual(proof.image_thumb_path, "0001/1.400.webp")
 
 
 class PriceTagListApiTest(TestCase):

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -1163,6 +1163,14 @@ class ProofDraftAnonymizeApiTest(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 200)
+        self.assertDictContainsSubset(
+            {
+                "id": receipt_draft_proof.id,
+                "file_path": "0001/1.webp",
+                "image_thumb_path": "0001/1.400.webp",
+            },
+            response.data,
+        )
 
         # We uploaded a JPEG image, check that it's not on disk anymore (converted to WEBP)
         self.assertFalse(image_path.exists())

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -297,7 +297,9 @@ class ProofDraftViewSet(
         Only the file and type fields are expected. ML models runs immediately asynchronously."""
         return base_upload(request, draft=True)
 
-    @extend_schema(request=DraftProofAnonymizeRequestSerializer)
+    @extend_schema(
+        request=DraftProofAnonymizeRequestSerializer, responses=ProofFullSerializer
+    )
     @action(
         detail=True,
         methods=["POST"],
@@ -341,7 +343,7 @@ class ProofDraftViewSet(
             proof._change_reason = "Saving new image path after anonymization"
             proof.save()
 
-        return Response(status=status.HTTP_200_OK)
+        return Response(ProofFullSerializer(proof).data, status=status.HTTP_200_OK)
 
     @extend_schema(request=ProofUpdateSerializer, responses=ProofFullSerializer)
     def partial_update(self, request: Request, pk=None) -> Response:

--- a/open_prices/api/proofs/views.py
+++ b/open_prices/api/proofs/views.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import PIL.Image
 from django.conf import settings
 from django_filters.rest_framework import DjangoFilterBackend
@@ -20,6 +22,7 @@ from open_prices.api.proofs.filters import (
     ReceiptItemFilter,
 )
 from open_prices.api.proofs.serializers import (
+    DraftProofAnonymizeRequestSerializer,
     PriceTagCreateSerializer,
     PriceTagFullSerializer,
     PriceTagUpdateSerializer,
@@ -44,9 +47,14 @@ from open_prices.common.permission import (
     OnlyObjectOwnerOrModeratorIsAllowedWrite,
 )
 from open_prices.proofs import constants as proof_constants
+from open_prices.proofs.constants import TYPE_RECEIPT
 from open_prices.proofs.ml.price_tags import extract_from_price_tag
 from open_prices.proofs.models import PriceTag, Proof, ReceiptItem
-from open_prices.proofs.utils import compute_file_md5, store_file
+from open_prices.proofs.utils import (
+    compute_file_md5,
+    save_anonymized_receipt,
+    store_file,
+)
 
 
 def base_upload(request: Request, draft: bool = False) -> Response:
@@ -288,6 +296,52 @@ class ProofDraftViewSet(
 
         Only the file and type fields are expected. ML models runs immediately asynchronously."""
         return base_upload(request, draft=True)
+
+    @extend_schema(request=DraftProofAnonymizeRequestSerializer)
+    @action(
+        detail=True,
+        methods=["POST"],
+        url_path="anonymize",
+    )
+    def anonymize_receipt(self, request: Request, pk=None) -> Response:
+        """Anonymize a receipt."""
+        proof = self.get_object()
+
+        # No need to check that this is a draft proof, as the queryset filter ensures it
+        if proof.type != TYPE_RECEIPT:
+            return Response(
+                {"detail": "Only receipts can be anonymized"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Warning: bounding boxes here have the same format [x_min, y_min, x_max, y_max]
+        # as the `Word` bounding boxes in the OCR results.
+        # Currently, the format used by the bounding boxes of price tags use a different
+        # format ([y_min, x_min, y_max, x_max]).
+        # The [x_min, y_min, x_max, y_max] format is much more common, and we should migrate
+        # price tag bounding boxes to that format in the future for consistency.
+        serializer = DraftProofAnonymizeRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        image_path = Path(proof.file_path)
+        image_thumb_path = Path(proof.image_thumb_path)
+        # Redact the personal information from the image by drawing black boxes over
+        # the bounding boxes, and save the new image and thumbnail to the filesystem.
+        # We don't update the image hash, so that the proof duplication detection
+        # still works.
+        new_image_path, new_image_thumb_path = save_anonymized_receipt(
+            image_path=image_path,
+            image_thumb_path=image_thumb_path,
+            bounding_boxes=serializer.data["bounding_boxes"],
+        )
+
+        if new_image_path != image_path or new_image_thumb_path != image_thumb_path:
+            proof.file_path = str(new_image_path)
+            proof.image_thumb_path = str(new_image_thumb_path)
+            proof._change_reason = "Saving new image path after anonymization"
+            proof.save()
+
+        return Response(status=status.HTTP_200_OK)
 
     @extend_schema(request=ProofUpdateSerializer, responses=ProofFullSerializer)
     def partial_update(self, request: Request, pk=None) -> Response:

--- a/open_prices/proofs/tests.py
+++ b/open_prices/proofs/tests.py
@@ -68,6 +68,7 @@ from open_prices.proofs.utils import (
     match_price_tag_with_price,
     match_product_price_tag_with_product_price,
     match_receipt_item_with_price,
+    save_anonymized_receipt,
     select_proof_image_dir,
 )
 from open_prices.users.factories import SessionFactory
@@ -2168,3 +2169,49 @@ class GenerateImageThumbnailCv2Test(TestCase):
         result = generate_image_thumbnail_cv2(image, max_size=200)
         self.assertEqual(result.shape[0], 133)
         self.assertEqual(result.shape[1], 200)
+
+
+class TestSaveAnonymizedReceipt(unittest.TestCase):
+    def test_save_anonymized_receipt(self):
+        with tempfile.TemporaryDirectory() as tmpdir_str:
+            # Save as JPEG
+            root_dir = Path(tmpdir_str)
+            proof_dir = root_dir / "0002"
+            proof_dir.mkdir(parents=True)
+            full_image_path = proof_dir / "full.jpg"
+            # Create a test image (white color)
+            height = 400
+            width = 600
+            image = np.ones((height, width, 3), dtype=np.uint8) * 255
+            cv2.imwrite(str(full_image_path), image)
+            cv2.imwrite(str(proof_dir / "thumbnail.jpg"), cv2.resize(image, (400, 400)))
+            bounding_boxes = [
+                [0.2, 0.5, 0.25, 0.60],  # absolute: (120, 200, 150, 240)
+                [0.3, 0.6, 0.40, 0.65],  # absolute: (180, 240, 240, 260)
+            ]
+            new_image_path, new_thumb_path = save_anonymized_receipt(
+                image_path=Path("0002/full.jpg"),
+                image_thumb_path=Path("0002/thumbnail.jpg"),
+                bounding_boxes=bounding_boxes,
+                root_dir=root_dir,
+            )
+
+            # Check that new files are now WEBP images, with relative paths preserved
+            self.assertEqual(str(new_image_path), "0002/full.webp")
+            self.assertEqual(str(new_thumb_path), "0002/thumbnail.webp")
+            new_image = cv2.imread(str(root_dir / new_image_path))
+            self.assertIsNotNone(new_image)
+            self.assertIsNotNone(cv2.imread(str(root_dir / new_thumb_path)))
+            self.assertEqual(new_image.shape[0], height)
+            self.assertEqual(new_image.shape[1], width)
+            # check that the areas corresponding to the bounding boxes are in black color
+            for box in bounding_boxes:
+                x_min, y_min, x_max, y_max = box
+                x_min, y_min, x_max, y_max = (
+                    int(x_min * width),
+                    int(y_min * height),
+                    int(x_max * width),
+                    int(y_max * height),
+                )
+                area = new_image[y_min:y_max, x_min:x_max]
+                self.assertTrue(np.all(area == 0))

--- a/open_prices/proofs/utils.py
+++ b/open_prices/proofs/utils.py
@@ -90,7 +90,7 @@ def generate_thumbnail(
     file_stem: str,
     extension: str,
     mimetype: str,
-    thumbnail_size: tuple[int, int] = settings.THUMBNAIL_SIZE,
+    thumbnail_size: int = settings.THUMBNAIL_SIZE,
 ) -> str | None:
     """Generate a thumbnail for the image at the given path."""
     if not mimetype.startswith("image"):
@@ -104,9 +104,9 @@ def generate_thumbnail(
         # set any rotation info
         img_thumb = ImageOps.exif_transpose(img)
         # transform into a thumbnail
-        img_thumb.thumbnail(thumbnail_size, Image.Resampling.LANCZOS)
+        img_thumb.thumbnail((thumbnail_size, thumbnail_size), Image.Resampling.LANCZOS)
         image_thumb_full_path = generate_full_path(
-            current_dir, f"{file_stem}.{settings.THUMBNAIL_SIZE[0]}", extension
+            current_dir, f"{file_stem}.{thumbnail_size}", extension
         )
         # avoid 'cannot write mode RGBA/LA/P as JPEG' error
         if mimetype in ("image/jpeg",) and img_thumb.mode in ("RGBA", "LA", "P"):
@@ -115,7 +115,7 @@ def generate_thumbnail(
         img_thumb.save(image_thumb_full_path)
         return generate_relative_path(
             current_dir_id_str,
-            f"{file_stem}.{settings.THUMBNAIL_SIZE[0]}",
+            f"{file_stem}.{thumbnail_size}",
             extension,
         )
 
@@ -150,6 +150,70 @@ def store_file(
     # Build file_path
     file_path = generate_relative_path(current_dir.name, file_stem, extension)
     return (file_path, mimetype, image_thumb_path)
+
+
+def save_anonymized_receipt(
+    image_path: Path,
+    image_thumb_path: Path,
+    bounding_boxes: list[list[float]],
+    root_dir: Path | None = None,
+) -> tuple[Path, Path]:
+    """Redact areas of the proof image containing personal information with black
+    boxes, and save the new image and thumbnail to the filesystem.
+
+    :param image_path: the path to the image file (original-size image)
+    :param image_thumb_path: the path to the thumbnail file
+    :param bounding_boxes: a list of bounding boxes to redact, in the format
+        [x_min, y_min, x_max, y_max]
+    :param root_dir: the root directory that the image paths are relative to, defaults to
+        settings.IMAGES_DIR
+    :return: the relative paths to the new image and thumbnail files
+    """
+    if not bounding_boxes:
+        raise ValueError("bounding_boxes must not be empty")
+    if root_dir is None:
+        root_dir = settings.IMAGES_DIR
+
+    image_full_path = root_dir / image_path
+    image_thumb_full_path = root_dir / image_thumb_path
+    image = open_image_cv2(image_full_path)
+    for bounding_box in bounding_boxes:
+        x_min, y_min, x_max, y_max = bounding_box
+        height = image.shape[0]
+        width = image.shape[1]
+        y_min_px = int(y_min * height)
+        x_min_px = int(x_min * width)
+        y_max_px = int(y_max * height)
+        x_max_px = int(x_max * width)
+        # Draw a black box over the bounding box area
+        image = cv2.rectangle(
+            image,
+            (x_min_px, y_min_px),
+            (x_max_px, y_max_px),
+            # black color
+            (0, 0, 0),
+            thickness=cv2.FILLED,
+        )
+    image_to_remove_paths = []
+    if image_path.suffix != ".webp":
+        # The original image is not necessarily a webp, force webp format here
+        image_to_remove_paths.append(image_full_path)
+        image_full_path = Path(image_full_path).with_suffix(".webp")
+    if image_thumb_path.suffix != ".webp":
+        image_to_remove_paths.append(image_thumb_full_path)
+        image_thumb_full_path = image_thumb_full_path.with_suffix(".webp")
+
+    cv2.imwrite(str(image_full_path), image)
+    thumb_image = generate_image_thumbnail_cv2(image)
+    cv2.imwrite(str(image_thumb_full_path), thumb_image)
+
+    for path in image_to_remove_paths:
+        # Remove the original image if it was converted to webp
+        path.unlink()
+
+    image_path = image_full_path.relative_to(root_dir)
+    thumb_path = image_thumb_full_path.relative_to(root_dir)
+    return image_path, thumb_path
 
 
 def compute_file_md5(file: InMemoryUploadedFile | TemporaryUploadedFile) -> str:
@@ -189,7 +253,7 @@ def compute_file_md5_from_path(file_path: Path) -> str:
 
 
 def select_proof_image_dir(images_dir: Path, max_images_per_dir: int = 1_000) -> Path:
-    """ "Select the directory where to store the image.
+    """Select the directory where to store the image.
 
     We create a new directory when the current one contains more than 1000
     images. The directories are named with a 4-digit number, starting at 0001.
@@ -365,7 +429,9 @@ def open_image_cv2(image_path: str | Path, rgb: bool = False) -> np.ndarray:
     return image  # type: ignore
 
 
-def generate_image_thumbnail_cv2(image: np.ndarray, max_size: int) -> np.ndarray:
+def generate_image_thumbnail_cv2(
+    image: np.ndarray, max_size: int = settings.THUMBNAIL_SIZE
+) -> np.ndarray:
     """Generate a thumbnail for the given image using OpenCV.
 
     :param image: the image to generate a thumbnail for, as a numpy array
@@ -377,7 +443,9 @@ def generate_image_thumbnail_cv2(image: np.ndarray, max_size: int) -> np.ndarray
         scaling_factor = max_size / max(width, height)
         new_width = int(width * scaling_factor)
         new_height = int(height * scaling_factor)
-        image = cv2.resize(image, (new_width, new_height), interpolation=cv2.INTER_AREA)
+        image = cv2.resize(
+            image, (new_width, new_height), interpolation=cv2.INTER_LANCZOS4
+        )
     return image
 
 


### PR DESCRIPTION
Add an API to anonymize draft receipts.
The front-end should fetch the RECEIPT_ANONYMIZATION prediction, display it to the user (who can optionally modify the areas to redact), and send the results back to this new route.
The route modifies the image in place on disk.