### PR TITLE
fix: remove unreachable elif in barcode_fix_short_codes_from_usa

### DIFF
--- a/open_prices/common/openfoodfacts.py
+++ b/open_prices/common/openfoodfacts.py
@@ -395,8 +395,7 @@ def barcode_fix_short_codes_from_usa(barcode: str) -> str:
     """
     Fix short barcodes from USA
 
-    10 or 11 digits: pad them to 12 digits and calculate their check digit
-    12 digits: add a leading zero
+    10, 11 or 12 digits: pad them to 12 digits and calculate their check digit
 
     This function is based on the fact that most of the short barcodes are from
     the USA, and that they can be converted to a valid EAN-13 barcode by
@@ -413,10 +412,6 @@ def barcode_fix_short_codes_from_usa(barcode: str) -> str:
         barcode_temp = barcode.zfill(12)
         barcode_check_digit = openfoodfacts.barcode.calculate_check_digit(barcode + "0")
         barcode_temp = barcode_temp + barcode_check_digit
-        if barcode_is_valid(barcode_temp):
-            return barcode_temp
-    elif len(barcode) == 12:
-        barcode_temp = "0" + barcode
         if barcode_is_valid(barcode_temp):
             return barcode_temp
     return barcode


### PR DESCRIPTION
Fixes #1367.

`barcode_fix_short_codes_from_usa` had a dead branch: the first condition already catches 10, 11, and 12-digit barcodes (`if len(barcode) in (10, 11, 12)`), so the `elif len(barcode) == 12` right after it could never run.

I didn't just delete it though, I checked whether the elif's own logic (prepend a single `"0"`) was actually the correct behavior for 12-digit codes and the fix should have made it reachable instead. It isn't: the existing test case `("471058718081", "4710587180816")` only works through the pad-and-check-digit branch. Prepending `"0"` gives `0471058718081`, which doesn't match. So removing the dead code is the right fix, not resurrecting it.

Also updated the docstring, since it still described the "12 digits: add a leading zero" behavior that the dead branch used to represent.

Verification: couldn't run the full Django test suite locally (needs Postgres + `.env`), but I installed the `openfoodfacts` package standalone and ran the fixed function's logic against all five cases from `test_barcode_fix_short_codes_from_usa` directly against the real `calculate_check_digit`/`has_valid_check_digit` implementations, all pass. Also ran `ruff check` and `ruff format --diff` against the touched file, both clean.
