### PR TITLE
feat(Moderation): create flags from price outliers

### DIFF
--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -17,7 +17,8 @@ from open_prices.common.openfoodfacts import import_product_db
 from open_prices.common.utils import export_model_to_jsonl_gz
 from open_prices.locations.models import Location
 from open_prices.moderation import rules as moderation_rules
-from open_prices.prices.models import Price
+from open_prices.moderation.rules import create_flags_from_price_outliers
+from open_prices.prices.models import Price, PriceStatistics5y
 from open_prices.products.models import Product
 from open_prices.proofs.models import Proof
 from open_prices.stats.models import TotalStats
@@ -125,6 +126,16 @@ def history_cleanup_task():
     history_clean_duplicate_command()
 
 
+def create_flags_from_price_outliers_and_update_view():
+    """Create flag associated with detected price outliers, for prices that were
+    created the day before.
+    Then refresh the `price_statistics_5y` materialized view."""
+    logger.info("Running create_flags_from_price_outliers task")
+    create_flags_from_price_outliers()
+    logger.info("Refreshing materialized view...")
+    PriceStatistics5y.refresh_materialized_view()
+
+
 CRON_SCHEDULES = {
     "import_obf_db_task": ("0 15 * * *", {}),  # daily at 15:00
     "import_opff_db_task": ("10 15 * * *", {}),  # daily at 15:10
@@ -134,6 +145,10 @@ CRON_SCHEDULES = {
     "fix_proof_fields_task": ("0 1 * * *", {}),  # daily at 01:00
     "moderation_tasks": ("10 1 * * *", {}),  # daily at 01:10
     "history_cleanup_task": ("20 1 * * *", {}),  # daily at 01:20
+    "create_flags_from_price_outliers_and_update_view": (  # daily at 00:30
+        "30 0 * * *",
+        {},
+    ),
     "update_challenge_task": ("30 1 * * *", {}),  # daily at 01:30
     "update_user_counts_task": ("0 2 * * *", {}),  # daily at 02:00
     "update_badge_task": ("5 2 * * *", {}),  # daily at 02:05

--- a/open_prices/moderation/rules.py
+++ b/open_prices/moderation/rules.py
@@ -2,12 +2,21 @@
 A list of rules, to clean up the data
 """
 
+import logging
+from datetime import timedelta
+
+from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.db.models.functions import Length
+from django.utils import timezone
 
 from open_prices.common import openfoodfacts as common_openfoodfacts
+from open_prices.moderation.models import Flag, FlagReason
 from open_prices.prices import constants as price_constants
+from open_prices.prices.outlier_detection import find_outliers
 from open_prices.products.models import Product
+
+logger = logging.getLogger(__name__)
 
 
 def cleanup_products_with_long_barcodes():
@@ -88,3 +97,37 @@ def cleanup_products_with_invalid_barcodes():
 
     # recap
     print(f"Deleted {product_deleted_count} products and {price_deleted_count} prices")
+
+
+def create_flags_from_price_outliers():
+    """Create flags for each outlier detected, for prices that were created the day before.
+
+    By running this task after midnight (UTC), and refreshing the `price_statistics_5y` after,
+    we ensure that new prices don't skew the median value, that is used to detect outliers.
+    """
+    yesterday = (timezone.now() - timedelta(days=1)).date()
+    outliers = list(find_outliers(target_date=yesterday))
+
+    # As we cannot directly filter per content type without adding a GenericRelation
+    # to the Price model, we simply fetch the content type associated with the price
+    # table here
+    price_content_type = ContentType.objects.get(app_label="prices", model="price")
+    for price in outliers:
+        is_higher = price.price >= price.median
+        if Flag.objects.filter(
+            object_id=price.id,
+            content_type=price_content_type,
+            reason=FlagReason.WRONG_PRICE_VALUE,
+        ).count():
+            continue
+        flag = Flag.objects.create(
+            content_object=price,
+            reason=FlagReason.WRONG_PRICE_VALUE,
+            source="outlier-detection",
+            comment=(
+                f"Price is {'higher' if is_higher else 'lower'} than "
+                f"{'3 * median' if is_higher else 'median / 3'} "
+                f"(price: {price.price}, median: {price.median})"
+            ),
+        )
+        logger.info("New flag created for price outlier %s: %s", price.id, flag)

--- a/open_prices/moderation/tests.py
+++ b/open_prices/moderation/tests.py
@@ -1,14 +1,20 @@
+from datetime import timedelta
+
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import timezone
 
+from open_prices.locations.factories import LocationFactory
 from open_prices.moderation.models import Flag, FlagReason, FlagStatus
 from open_prices.moderation.rules import (
     cleanup_products_with_invalid_barcodes,
     cleanup_products_with_long_barcodes,
+    create_flags_from_price_outliers,
 )
+from open_prices.prices import constants as price_constants
 from open_prices.prices.factories import PriceFactory
-from open_prices.prices.models import Price
+from open_prices.prices.models import Price, PriceStatistics5y
 from open_prices.products import constants as product_constants
 from open_prices.products.factories import ProductFactory
 from open_prices.products.models import Product
@@ -240,3 +246,48 @@ class ModerationRulesTest(TestCase):
         cleanup_products_with_invalid_barcodes()
         self.assertEqual(Product.objects.count(), 2)  # 1 product deleted
         self.assertEqual(Price.objects.count(), 3)  # 2 prices deleted
+
+
+class TestCreateFlagsFromPriceOutliers(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.product_code = "0123456789100"
+        cls.product = ProductFactory(code=cls.product_code)
+        cls.location = LocationFactory(osm_address_country_code="FR")
+        product_base_price = {
+            "product_code": cls.product_code,
+            "product": cls.product,
+            "type": price_constants.TYPE_PRODUCT,
+            "location": cls.location,
+            "location_osm_id": cls.location.osm_id,
+            "location_osm_type": cls.location.osm_type,
+            "price_per": None,
+            "currency": "EUR",
+            "created": (timezone.now() - timedelta(days=1)).date(),
+        }
+        cls.outlier_price = None
+        for price in [
+            "4.5",
+            "5.0",
+            # 6.0 is the median
+            "6.0",
+            "8.0",
+            # 19 is an outlier with `median_threshold=3` (i.e. 3 times the median)
+            "19",
+        ]:
+            price_obj = PriceFactory(price=price, **product_base_price)
+            if price == "19":
+                cls.outlier_price = price_obj
+        PriceStatistics5y.refresh_materialized_view()
+
+    def test_create_flags_from_price_outliers(self):
+        self.assertEqual(Flag.objects.count(), 0)
+        create_flags_from_price_outliers()
+        flags = list(Flag.objects.all())
+        self.assertEqual(len(flags), 1)
+        flag = flags[0]
+        self.assertEqual(flag.object_id, self.outlier_price.id)
+        self.assertEqual(flag.reason, "WRONG_PRICE_VALUE")
+        self.assertEqual(
+            flag.comment, "Price is higher than 3 * median (price: 19.000, median: 6.0)"
+        )


### PR DESCRIPTION
Following #1377

Every night, run a task to:

- create flags from price outliers, for prices created the day before
- refresh the `price_statistics_5y` materialized view