### PR TITLE
fix: improve flag creation from price outliers

### DIFF
--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -142,13 +142,13 @@ CRON_SCHEDULES = {
     "import_opf_db_task": ("20 15 * * *", {}),  # daily at 15:20
     "import_off_db_task": ("30 15 * * *", {}),  # daily at 15:30
     "dump_db_task": ("0 23 * * *", {}),  # daily at 23:00
-    "fix_proof_fields_task": ("0 1 * * *", {}),  # daily at 01:00
-    "moderation_tasks": ("10 1 * * *", {}),  # daily at 01:10
-    "history_cleanup_task": ("20 1 * * *", {}),  # daily at 01:20
     "create_flags_from_price_outliers_and_update_view": (  # daily at 00:30
         "30 0 * * *",
         {},
     ),
+    "fix_proof_fields_task": ("0 1 * * *", {}),  # daily at 01:00
+    "moderation_tasks": ("10 1 * * *", {}),  # daily at 01:10
+    "history_cleanup_task": ("20 1 * * *", {}),  # daily at 01:20
     "update_challenge_task": ("30 1 * * *", {}),  # daily at 01:30
     "update_user_counts_task": ("0 2 * * *", {}),  # daily at 02:00
     "update_badge_task": ("5 2 * * *", {}),  # daily at 02:05

--- a/open_prices/moderation/rules.py
+++ b/open_prices/moderation/rules.py
@@ -99,14 +99,16 @@ def cleanup_products_with_invalid_barcodes():
     print(f"Deleted {product_deleted_count} products and {price_deleted_count} prices")
 
 
-def create_flags_from_price_outliers():
-    """Create flags for each outlier detected, for prices that were created the day before.
+def create_flags_from_price_outliers(only_yesterday: bool = True):
+    """Create flags for each price outlier detected.
 
-    By running this task after midnight (UTC), and refreshing the `price_statistics_5y` after,
-    we ensure that new prices don't skew the median value, that is used to detect outliers.
+    :param only_yesterday: if True, only look for outliers for prices that were
+        created yesterday.
     """
-    yesterday = (timezone.now() - timedelta(days=1)).date()
-    outliers = list(find_outliers(target_date=yesterday))
+    target_date = (
+        (timezone.now() - timedelta(days=1)).date() if only_yesterday else None
+    )
+    outliers = list(find_outliers(target_date=target_date))
 
     # As we cannot directly filter per content type without adding a GenericRelation
     # to the Price model, we simply fetch the content type associated with the price


### PR DESCRIPTION
Following #1377

- add only_yesterday flag, so that we can easily create flags for all prices
- reorder scheduled tasks