### PR TITLE
feat(Badges): API: endpoint to list users who achieved a specific badge

### DIFF
--- a/open_prices/api/badges/serializers.py
+++ b/open_prices/api/badges/serializers.py
@@ -1,11 +1,20 @@
 from rest_framework import serializers
 
+from open_prices.api.users.serializers import UserSerializer
 from open_prices.badges.models import Badge, UserBadge
 
 
 class BadgeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Badge
+        fields = "__all__"
+
+
+class BadgeUserSerializer(serializers.ModelSerializer):
+    user = UserSerializer(read_only=True)
+
+    class Meta:
+        model = UserBadge
         fields = "__all__"
 
 

--- a/open_prices/api/badges/tests.py
+++ b/open_prices/api/badges/tests.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 from django.urls import reverse
 
 from open_prices.badges.factories import BadgeFactory
-from open_prices.users.factories import SessionFactory
+from open_prices.badges.models import Badge
+from open_prices.users.factories import SessionFactory, UserFactory
 
 
 class BadgeListApiTest(TestCase):
@@ -128,3 +129,52 @@ class BadgeDeleteApiTest(TestCase):
             self.url, headers={"Authorization": f"Bearer {self.user_session.token}"}
         )
         self.assertEqual(response.status_code, 405)
+
+
+class BadgeUserListApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(price_count=15)
+        cls.badge = BadgeFactory(metric="price_count", threshold=10)
+        cls.url = reverse("api:badges-users", args=[cls.badge.id])
+
+    def test_badge_users_list(self):
+        # Update user badges and count
+        Badge.update_task()
+        self.badge.refresh_from_db()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        user_badge = self.user.user_badges.get(badge=self.badge)
+        self.assertEqual(response.data[0]["id"], user_badge.id)
+        self.assertEqual(response.data[0]["badge"], self.badge.id)
+        self.assertEqual(response.data[0]["user"]["user_id"], self.user.user_id)
+        self.assertIn("achieved_at", response.data[0])
+
+    def test_badge_users_list_empty(self):
+        self.badge.threshold = 100
+        self.badge.save()
+
+        # Update user badges and count
+        Badge.update_task()
+        self.badge.refresh_from_db()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+    def test_badge_users_only_returns_achieved_users(self):
+        # Create a user that does not meet the badge threshold
+        UserFactory(price_count=5)
+
+        # Update user badges and count
+        Badge.update_task()
+        self.badge.refresh_from_db()
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)  # Only the user that met the threshold

--- a/open_prices/api/badges/views.py
+++ b/open_prices/api/badges/views.py
@@ -1,7 +1,11 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 from rest_framework import filters, mixins, viewsets
+from rest_framework.decorators import action
+from rest_framework.request import Request
+from rest_framework.response import Response
 
-from open_prices.api.badges.serializers import BadgeSerializer
+from open_prices.api.badges.serializers import BadgeSerializer, BadgeUserSerializer
 from open_prices.badges.models import Badge
 
 
@@ -13,3 +17,11 @@ class BadgeViewSet(
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     ordering_fields = ["id", "user_count", "created"]
     ordering = ["id"]
+
+    @extend_schema(responses=BadgeUserSerializer(many=True), filters=False)
+    @action(detail=True, methods=["GET"])
+    def users(self, request: Request, pk=None) -> Response:
+        badge = self.get_object()
+        users = badge.user_badges.select_related("user").all()
+        serializer = BadgeUserSerializer(users, many=True)
+        return Response(serializer.data, status=200)

--- a/open_prices/api/users/tests.py
+++ b/open_prices/api/users/tests.py
@@ -154,7 +154,7 @@ class UserBadgeListApiTest(TestCase):
         self.assertEqual(response.data[0]["user"], self.user.user_id)
         self.assertIn("achieved_at", response.data[0])
 
-    def test_user_badges_list_for_user_without_badges(self):
+    def test_user_badges_list_empty(self):
         # Make the user not meet the threshold for the badge
         self.user.price_count = 5
         self.user.save()


### PR DESCRIPTION
### What

In #1366 we added an endpoint to get a the list of user's badges: `/users/:id/badges`

Here we add an endpoint to get the list of badge's users: `/badges/:id/users`

### Why

for the frontend