### PR TITLE
refactor(Locations): API: always paginate the `/nearby` endpoint

### DIFF
--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -454,6 +454,14 @@ class LocationNearbyApiTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
+    def test_nearby_no_results(self):
+        url = f"{self.url}?lat=0&lon=0&radius_km=5"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("items", response.data)
+        self.assertEqual(response.data["total"], 0)
+        self.assertEqual(len(response.data["items"]), 0)
+
     def test_nearby_radius_km_zero(self):
         url = f"{self.url}?lat={self.CENTER_LAT}&lon={self.CENTER_LON}&radius_km=0"
         response = self.client.get(url)

--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -420,7 +420,7 @@ class LocationNearbyApiTest(TestCase):
         cls.location_online = LocationFactory(type=location_constants.TYPE_ONLINE)
 
     def test_nearby_missing_params(self):
-        # all missing
+        # lat, lon & radius_km missing
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 400)
         # lat missing
@@ -465,7 +465,6 @@ class LocationNearbyApiTest(TestCase):
         url = f"{self.url}?lat={self.CENTER_LAT}&lon={self.CENTER_LON}&radius_km=5"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("items", response.data)
         self.assertEqual(response.data["total"], 2)  # center + near
         # ordered by distance
         self.assertEqual(response.data["items"][0]["id"], self.location_osm_center.id)
@@ -473,6 +472,27 @@ class LocationNearbyApiTest(TestCase):
         # distance_km in response
         self.assertAlmostEqual(response.data["items"][0]["distance_km"], 0.0, places=2)
         self.assertAlmostEqual(response.data["items"][1]["distance_km"], 1.3, delta=0.1)
+
+    def test_nearby_pagination(self):
+        url = (
+            f"{self.url}?lat={self.CENTER_LAT}&lon={self.CENTER_LON}&radius_km=5&size=1"
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 2)  # center + near
+        self.assertEqual(response.data["size"], 1)
+        self.assertEqual(response.data["pages"], 2)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(len(response.data["items"]), 1)
+
+        url = f"{self.url}?lat={self.CENTER_LAT}&lon={self.CENTER_LON}&radius_km=5&size=1&page=2"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 2)  # center + near
+        self.assertEqual(response.data["size"], 1)
+        self.assertEqual(response.data["pages"], 2)
+        self.assertEqual(response.data["page"], 2)
+        self.assertEqual(len(response.data["items"]), 1)
 
 
 class LocationCompareApiTest(TestCase):

--- a/open_prices/api/locations/views.py
+++ b/open_prices/api/locations/views.py
@@ -20,6 +20,7 @@ from open_prices.api.locations.serializers import (
     LocationNearbySerializer,
     LocationSerializer,
 )
+from open_prices.api.pagination import CustomPagination
 from open_prices.api.utils import get_object_or_drf_404, get_source_from_request
 from open_prices.common import openstreetmap, utils
 from open_prices.locations import constants as location_constants
@@ -95,7 +96,6 @@ class LocationViewSet(
         serializer = self.get_serializer(location)
         return Response(serializer.data)
 
-    # TODO: disable pagination
     @extend_schema(responses=CountrySerializer(many=True), filters=False)
     @action(detail=False, methods=["GET"], url_path="osm/countries")
     def list_osm_countries(self, request):
@@ -137,7 +137,6 @@ class LocationViewSet(
 
         return Response(countries_list)
 
-    # TODO: disable pagination
     @extend_schema(responses=CountryCitySerializer(many=True), filters=False)
     @action(
         detail=False,
@@ -200,13 +199,10 @@ class LocationViewSet(
         radius_km = params_serializer.validated_data["radius_km"]
         queryset = Location.objects.nearby(center_lat, center_lon, radius_km)
 
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = LocationNearbySerializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-
-        serializer = LocationNearbySerializer(queryset, many=True)
-        return Response(serializer.data)
+        paginator = CustomPagination()
+        page = paginator.paginate_queryset(queryset, request)
+        serializer = LocationNearbySerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
 
     @extend_schema(
         parameters=[


### PR DESCRIPTION
### What

Following #1303
Here we make a small fix to make sure that the `/nearby` answer is always paginated

Add tests

