### PR TITLE
refactor(Badges): API: add pagination and ordering on the users list endpoint

### DIFF
--- a/open_prices/api/badges/tests.py
+++ b/open_prices/api/badges/tests.py
@@ -146,12 +146,14 @@ class BadgeUserListApiTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data["items"]), 1)
         user_badge = self.user.user_badges.get(badge=self.badge)
-        self.assertEqual(response.data[0]["id"], user_badge.id)
-        self.assertEqual(response.data[0]["badge"], self.badge.id)
-        self.assertEqual(response.data[0]["user"]["user_id"], self.user.user_id)
-        self.assertIn("achieved_at", response.data[0])
+        self.assertEqual(response.data["items"][0]["id"], user_badge.id)
+        self.assertEqual(response.data["items"][0]["badge"], self.badge.id)
+        self.assertEqual(
+            response.data["items"][0]["user"]["user_id"], self.user.user_id
+        )
+        self.assertIn("achieved_at", response.data["items"][0])
 
     def test_badge_users_list_empty(self):
         self.badge.threshold = 100
@@ -164,7 +166,7 @@ class BadgeUserListApiTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(len(response.data["items"]), 0)
 
     def test_badge_users_only_returns_achieved_users(self):
         # Create a user that does not meet the badge threshold
@@ -177,4 +179,33 @@ class BadgeUserListApiTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)  # Only the user that met the threshold
+        self.assertEqual(
+            len(response.data["items"]), 1
+        )  # Only the user that met the threshold
+
+    def test_badge_users_list_pagination(self):
+        # Create additional users that meet the badge threshold
+        for _ in range(15):
+            UserFactory(price_count=20)
+
+        # Update user badges and count
+        Badge.update_task()
+        self.badge.refresh_from_db()
+
+        url = self.url + "?size=1"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1 + 15)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 16)
+
+        url = self.url + "?size=1&page=2"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1 + 15)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["page"], 2)
+        self.assertEqual(response.data["pages"], 16)

--- a/open_prices/api/badges/views.py
+++ b/open_prices/api/badges/views.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from open_prices.api.badges.serializers import BadgeSerializer, BadgeUserSerializer
+from open_prices.api.pagination import CustomPagination
 from open_prices.badges.models import Badge
 
 
@@ -22,6 +23,10 @@ class BadgeViewSet(
     @action(detail=True, methods=["GET"])
     def users(self, request: Request, pk=None) -> Response:
         badge = self.get_object()
-        users = badge.user_badges.select_related("user").all()
-        serializer = BadgeUserSerializer(users, many=True)
-        return Response(serializer.data, status=200)
+        queryset = badge.user_badges.select_related("user").all()
+        queryset = queryset.order_by("-achieved_at")  # order by achieved_at ASC
+        # paginate the response
+        paginator = CustomPagination()
+        page = paginator.paginate_queryset(queryset, request)
+        serializer = BadgeUserSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/open_prices/api/locations/tests.py
+++ b/open_prices/api/locations/tests.py
@@ -481,7 +481,7 @@ class LocationNearbyApiTest(TestCase):
         self.assertAlmostEqual(response.data["items"][0]["distance_km"], 0.0, places=2)
         self.assertAlmostEqual(response.data["items"][1]["distance_km"], 1.3, delta=0.1)
 
-    def test_nearby_pagination(self):
+    def test_nearby_list_pagination(self):
         url = (
             f"{self.url}?lat={self.CENTER_LAT}&lon={self.CENTER_LON}&radius_km=5&size=1"
         )

--- a/open_prices/api/locations/views.py
+++ b/open_prices/api/locations/views.py
@@ -198,7 +198,7 @@ class LocationViewSet(
         center_lon = params_serializer.validated_data["lon"]
         radius_km = params_serializer.validated_data["radius_km"]
         queryset = Location.objects.nearby(center_lat, center_lon, radius_km)
-
+        # paginate the response
         paginator = CustomPagination()
         page = paginator.paginate_queryset(queryset, request)
         serializer = LocationNearbySerializer(page, many=True)


### PR DESCRIPTION
### What

Following #1388
The endpoint was not paginated. It returned ALL of the users who achieved the badge. And the frontend was crashing.

- much better to add pagination (similar to #1389)
- also order_by most recently achieved
