### PR TITLE
refactor(Badges): API: add pagination and ordering on the user badges list endpoint

### DIFF
--- a/open_prices/api/badges/tests.py
+++ b/open_prices/api/badges/tests.py
@@ -185,8 +185,7 @@ class BadgeUserListApiTest(TestCase):
 
     def test_badge_users_list_pagination(self):
         # Create additional users that meet the badge threshold
-        for _ in range(15):
-            UserFactory(price_count=20)
+        UserFactory.create_batch(15, price_count=20)
 
         # Update user badges and count
         Badge.update_task()

--- a/open_prices/api/users/tests.py
+++ b/open_prices/api/users/tests.py
@@ -148,11 +148,11 @@ class UserBadgeListApiTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["id"], user_badge.id)
-        self.assertEqual(response.data[0]["badge"]["id"], self.badge.id)
-        self.assertEqual(response.data[0]["user"], self.user.user_id)
-        self.assertIn("achieved_at", response.data[0])
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["items"][0]["id"], user_badge.id)
+        self.assertEqual(response.data["items"][0]["badge"]["id"], self.badge.id)
+        self.assertEqual(response.data["items"][0]["user"], self.user.user_id)
+        self.assertIn("achieved_at", response.data["items"][0])
 
     def test_user_badges_list_empty(self):
         # Make the user not meet the threshold for the badge
@@ -166,7 +166,7 @@ class UserBadgeListApiTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(len(response.data["items"]), 0)
 
     def test_user_badges_list_only_returns_achieved_badges(self):
         # Create a badge that the user has not achieved
@@ -179,8 +179,34 @@ class UserBadgeListApiTest(TestCase):
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]["badge"]["id"], self.badge.id)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["items"][0]["badge"]["id"], self.badge.id)
+
+    def test_user_badges_list_pagination(self):
+        # Create additional badges that the user has achieved
+        BadgeFactory.create_batch(15, metric="price_count", threshold=5)
+
+        # Update user badges and count
+        Badge.update_task()
+        self.user.refresh_from_db()
+
+        url = self.url + "?size=1"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1 + 15)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["page"], 1)
+        self.assertEqual(response.data["pages"], 16)
+
+        url = self.url + "?size=1&page=2"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1 + 15)
+        self.assertEqual(len(response.data["items"]), 1)
+        self.assertEqual(response.data["page"], 2)
+        self.assertEqual(response.data["pages"], 16)
 
 
 class UserBadgeCreateApiTest(TestCase):

--- a/open_prices/api/users/views.py
+++ b/open_prices/api/users/views.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from open_prices.api.badges.serializers import UserBadgeSerializer
+from open_prices.api.pagination import CustomPagination
 from open_prices.api.users.filters import UserFilter
 from open_prices.api.users.serializers import UserSerializer
 from open_prices.users.models import User
@@ -32,6 +33,10 @@ class UserViewSet(
     @action(detail=True, methods=["GET"])
     def badges(self, request: Request, user_id=None) -> Response:
         user = self.get_object()
-        badges = user.user_badges.select_related("badge").all()
-        serializer = UserBadgeSerializer(badges, many=True)
-        return Response(serializer.data, status=200)
+        queryset = user.user_badges.select_related("badge").all()
+        queryset = queryset.order_by("id")
+        # paginate the response
+        paginator = CustomPagination()
+        page = paginator.paginate_queryset(queryset, request)
+        serializer = UserBadgeSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/open_prices/common/tests_managers.py
+++ b/open_prices/common/tests_managers.py
@@ -8,8 +8,7 @@ from open_prices.products.models import Product
 class ApproximateCountTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        for _ in range(10):
-            ProductFactory()
+        ProductFactory.create_batch(10)
 
     def test_approximate_count_without_filters(self):
         count = Product.objects.count()


### PR DESCRIPTION
### What

Following #1366
The endpoint was not paginated. It returned ALL of the user's achieved badges.
It's not as problematic as #1391 as there are not many badges yet.

But better to start paginating :)
Order by badge id
