### PR TITLE
fix: add permissions to top-issues GitHub Actions

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -1,4 +1,5 @@
-name: Top issues action.
+name: Top issues action
+
 on:
   schedule:
   - cron:  '0 0 */1 * *'
@@ -9,15 +10,17 @@ on:
 #  push:
 #    branches:
 #      - top-issues
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.
     runs-on: ubuntu-slim
     if: github.repository_owner == 'openfoodfacts'
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
     steps:
     - name: Run top issues action
       uses: rickstaa/top-issues-action@v1

--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -14,6 +14,10 @@ jobs:
     name: Display and label top issues.
     runs-on: ubuntu-slim
     if: github.repository_owner == 'openfoodfacts'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
     - name: Run top issues action
       uses: rickstaa/top-issues-action@v1


### PR DESCRIPTION
fix: add permissions to top-issues GitHub Actions

- `contents: read` (read repository metadata/content)
- `issues: write` (label/update issues and dashboard issue/comment if used)
- `pull-requests: write` (the action can include top pull requests and may update PR-related artifacts)
