### PR TITLE
fix(CI): add permissions to 'semantic PRs' GitHub Action

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
fix: add permissions to GitHub Actions

Add an explicit `permissions` block to `.github/workflows/semantic-pr.yml` so the `GITHUB_TOKEN` is restricted to the minimum required scope.  