### PR TITLE
fix: add permissions to GitHub Actions (add to github projects)

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -38,6 +38,8 @@ on:
     - review_request_removed
     - auto_merge_enabled
     - auto_merge_disabled
+permissions:
+  contents: read
 jobs:
   add-to-projects:
     name: Ventilate issues to the right GitHub projects


### PR DESCRIPTION
fix: add permissions to GitHub Actions (github projects) 

- `contents: read` (safe baseline commonly needed by actions/runtime metadata access)
