### PR TITLE
fix(ci): Workflow does not contain permissions (container-deploy.yml)

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  contents: read
+  actions: read
 
 # Note on secrets used for connection
 # They are configured as environment secrets


### PR DESCRIPTION
fix(ci): Workflow does not contain permissions (container-deploy.yml)

- `contents: read` (for repository metadata/content reads)
- `actions: read` (needed by actions that query workflow/check status, such as `wait-my-workflow`)

does it have enough permissions to do what it needs to do ?