### PR TITLE
fix(ci): Workflow does not contain permissions (container-build.yml)

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix(ci): Workflow does not contain permissions (container-build.yml)
- `contents: read` (needed for checkout/metadata)
- `packages: write` (needed to push images/cache to GHCR)

is it enough permissions ?