### PR TITLE
fix(ci): add permissions to pre-commit Github Action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ name: Run pre-commit hooks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix(ci): Workflow does not contain permissions (pre-commit.yml)

**File to change:** `.github/workflows/pre-commit.yml`  
**Change location:** after the `on:` trigger block (before `jobs:`), add:
```yml
permissions:
  contents: read
```

- [ ] check if enough permissions