### PR TITLE
fix(ci): Workflow does not contain permissions (generate-docs.yml)

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -17,8 +17,13 @@
         branches:
           - main
 
+    permissions:
+      contents: read
+
     jobs:
       publish-docs:
+        permissions:
+          contents: write
         runs-on: ubuntu-slim
         strategy:
           matrix:


### PR DESCRIPTION
fix(ci): Workflow does not contain permissions (generate-docs.yml)

- Add a workflow-level `permissions` block with `contents: read` (minimal baseline for checkout/read operations).
- Add a job-level `permissions` block for `publish-docs` with `contents: write`, since deployment to `gh-pages` requires pushing commits.

- [ ] check if enough permissions