### PR TITLE
fix(API): Price tags: prediction_count__lte filter was using price_count

### DIFF
--- a/open_prices/api/proofs/filters.py
+++ b/open_prices/api/proofs/filters.py
@@ -61,7 +61,7 @@ class PriceTagFilter(django_filters.FilterSet):
         field_name="prediction_count", lookup_expr="gte"
     )
     prediction_count__lte = django_filters.NumberFilter(
-        field_name="price_count", lookup_expr="lte"
+        field_name="prediction_count", lookup_expr="lte"
     )
     tags__contains = ArrayFieldElementContainsFilter(field_name="tags")
     tags__not_contains = ArrayFieldElementContainsFilter(

--- a/open_prices/api/proofs/tests.py
+++ b/open_prices/api/proofs/tests.py
@@ -1224,6 +1224,7 @@ class PriceTagListApiTest(TestCase):
             price=cls.price,
             status=proof_constants.PriceTagStatus.linked_to_price.value,
             tags=["prediction-found-product"],
+            prediction_count=2,
         )
         cls.price_tag_2 = PriceTagFactory(proof=cls.proof)
         cls.price_tag_3 = PriceTagFactory(
@@ -1296,6 +1297,21 @@ class PriceTagListApiTest(TestCase):
         # price tag 2 is returned
         self.assertEqual(response.data["items"][0]["id"], self.price_tag_2.id)
         url = self.url + "?status__isnull=False"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 2)
+
+    def test_price_tag_list_filter_by_prediction_count(self):
+        # exact
+        url = self.url + "?prediction_count=2"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["id"], self.price_tag_1.id)
+        # gte
+        url = self.url + "?prediction_count__gte=1"
+        response = self.client.get(url)
+        self.assertEqual(response.data["total"], 1)
+        # lte
+        url = self.url + "?prediction_count__lte=1"
         response = self.client.get(url)
         self.assertEqual(response.data["total"], 2)
 


### PR DESCRIPTION
linked to #695

### What

`PriceTagFilter.prediction_count__lte` declares `field_name="price_count"`, but `PriceTag` has no `price_count` field (that one lives on `Proof`). Looks like a copy/paste from `ProofFilter`.

So `GET /api/v1/price-tags?prediction_count__lte=1` raises a `FieldError` and returns a 500 instead of filtering. The `gte` version right above it is fine, only `lte` is affected.

### Repro

Added `test_price_tag_list_filter_by_prediction_count` to `PriceTagListApiTest`.

No docker on my machine, so I ran on the host: a local Postgres (that is what the `POSTGRES_*` overrides are for), an `img` directory created by hand because `settings.IMAGES_DIR` normally only exists inside the container, and `Q2_SYNC=True`, the same override `make tests` passes.

On main, with only the test applied:

```
$ Q2_SYNC=True POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=55432 uv run --env-file .env python manage.py test open_prices.api.proofs.tests.PriceTagListApiTest.test_price_tag_list_filter_by_prediction_count --noinput
django.core.exceptions.FieldError: Cannot resolve keyword 'price_count' into field. Choices are: bounding_box, created, created_by, id, prediction_count, predictions, price, price_id, proof, proof_id, proof_prediction, proof_prediction_id, status, tags, updated, updated_by

----------------------------------------------------------------------
Ran 1 test in 0.076s

FAILED (errors=1)
```

### Fix

Point the filter at `prediction_count`. One line.

The new test covers `prediction_count`, `prediction_count__gte` and `prediction_count__lte`, so the exact/gte paths stay covered too. `price_tag_1` now gets `prediction_count=2` in `setUpTestData` to give the filters something to select on.

### Tests

Whole suite on this branch:

```
$ Q2_SYNC=True POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=55432 uv run --env-file .env python manage.py test --noinput
Ran 467 tests in 26.305s

OK
```

Drop the `Q2_SYNC=True` and four challenge-tag tests fail, on main as much as here, which is why the Makefile and quality-check.yml both set it.

`uv run pre-commit run --files open_prices/api/proofs/filters.py open_prices/api/proofs/tests.py` passes.
