### PR TITLE
feat: accepter et logguer l'en-tête X-User-Agent (alignement avec l'API Open Food Facts)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -2,6 +2,8 @@ import os
 import sys
 from pathlib import Path
 
+from corsheaders.defaults import default_headers
+
 OPENFOODFACTS_URL = "https://world.openfoodfacts.org"
 OPENFOODFACTS_EMAIL = "contact@openfoodfacts.org"
 OPENPRICES_DOCS_URL = "https://openfoodfacts.github.io/open-prices/"
@@ -190,6 +192,12 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_CREDENTIALS = True
+# allow web clients to identify themselves with the X-User-Agent header
+# (same as the Open Food Facts API)
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    "x-user-agent",
+)
 
 
 # Pillow

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,7 +17,7 @@ http {
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" "$http_x_user_agent"';
 
     access_log  /var/log/nginx/access.log  main;
 
@@ -83,7 +83,7 @@ http {
                 # Add CORS headers
                 add_header 'Access-Control-Allow-Origin' '*';
                 add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+                add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
                 add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
             }
         }
@@ -94,7 +94,7 @@ http {
             # Add CORS headers
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
             add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
         }
     }


### PR DESCRIPTION

```
feat: accepter et logguer l'en-tête X-User-Agent (alignement avec l'API Open Food Facts)
```

# Description de la PR

## Quoi

- **`nginx.conf`** : ajout de `X-User-Agent` dans les directives CORS `Access-Control-Allow-Headers` (locations `/img` et `/data`), et ajout de `$http_x_user_agent` dans le format des logs d'accès.
- **`config/settings.py`** : extension de `CORS_ALLOW_HEADERS` (django-cors-headers) avec `x-user-agent` pour que les clients web puissent aussi l'envoyer sur les requêtes `/api/`.

## Pourquoi

L'API Open Food Facts autorise déjà cet en-tête — voir [`conf/nginx/snippets/cors-headers.include`](https://github.com/openfoodfacts/openfoodfacts-server/blob/main/conf/nginx/snippets/cors-headers.include) dans openfoodfacts-server :

```nginx
add_header Access-Control-Allow-Headers 'DNT,User-Agent,X-User-Agent,X-Requested-With,...' always;
```

Les navigateurs ne permettent pas à JavaScript de modifier l'en-tête standard `User-Agent` : `X-User-Agent` est donc le seul moyen pour une app web / un réutilisateur de s'identifier avec un nom personnalisé. Aujourd'hui, une requête cross-origin vers Open Prices incluant cet en-tête échoue au preflight CORS.

L'accepter et le logguer a un bénéfice opérationnel concret : les réutilisateurs deviennent identifiables dans les logs d'accès, ce qui permet de bloquer ou de limiter (rate-limit) une app spécifique qui enverrait de mauvaises données ou trop de requêtes — au lieu de ne voir qu'un User-Agent de navigateur générique.

Cela aligne Open Prices sur le comportement de l'API principale Open Food Facts.

## Changements

| Fichier | Changement |
|---|---|
| `nginx.conf` | `X-User-Agent` ajouté aux deux directives `Access-Control-Allow-Headers` |
| `nginx.conf` | `"$http_x_user_agent"` ajouté à la fin du format de log `main` |
| `config/settings.py` | `CORS_ALLOW_HEADERS = (*default_headers, "x-user-agent")` |

Remarque : aucun changement de logique applicative — l'en-tête est seulement autorisé (CORS) et loggué (nginx). 

## Tests

Preflight CORS sur l'API :

```bash
curl -s -X OPTIONS https://prices.openfoodfacts.org/api/v1/prices \
  -H "Origin: https://example.com" \
  -H "Access-Control-Request-Method: GET" \
  -H "Access-Control-Request-Headers: X-User-Agent" \
  -D - -o /dev/null | grep -i access-control
```

`access-control-allow-headers` doit inclure `x-user-agent`. Même vérification sur `/img/` et `/data/` pour les locations servies par nginx. Les requêtes envoyées avec `X-User-Agent: mon-app/1.0` doivent l'afficher dans le dernier champ du log d'accès nginx.
