### PR TITLE
feat(Prices): API: new geo filter (lat, lon & radius_km)

### DIFF
--- a/open_prices/api/prices/filters.py
+++ b/open_prices/api/prices/filters.py
@@ -1,11 +1,35 @@
 import django_filters
+from django import forms
 
 from open_prices.api.utils import ArrayFieldElementContainsFilter
 from open_prices.common import constants
 from open_prices.locations import constants as location_constants
+from open_prices.locations.models import Location
 from open_prices.prices.models import Price
 from open_prices.products import constants as product_constants
 from open_prices.proofs import constants as proof_constants
+
+NEARBY_PARAMETER_NAMES = ("lat", "lon", "radius_km")
+
+
+class PriceFilterForm(forms.Form):
+    def clean(self):
+        cleaned_data = super().clean()
+        provided_parameters = {
+            name for name in NEARBY_PARAMETER_NAMES if name in self.data
+        }
+        has_empty_parameter = any(
+            self.data.get(name) in (None, "") for name in provided_parameters
+        )
+        if provided_parameters and (
+            len(provided_parameters) != len(NEARBY_PARAMETER_NAMES)
+            or has_empty_parameter
+        ):
+            raise forms.ValidationError(
+                "lat, lon and radius_km must be provided together with non-empty "
+                "values."
+            )
+        return cleaned_data
 
 
 class PriceFilter(django_filters.FilterSet):
@@ -13,6 +37,26 @@ class PriceFilter(django_filters.FilterSet):
     PriceViewSet GET queryset has select_related on product, location, proof
     """
 
+    lat = django_filters.NumberFilter(
+        method="ignore_nearby_parameter",
+        min_value=-90,
+        max_value=90,
+        label="Latitude of the center point (-90 to 90). Must be sent together "
+        "with lon and radius_km.",
+    )
+    lon = django_filters.NumberFilter(
+        method="ignore_nearby_parameter",
+        min_value=-180,
+        max_value=180,
+        label="Longitude of the center point (-180 to 180). Must be sent together "
+        "with lat and radius_km.",
+    )
+    radius_km = django_filters.NumberFilter(
+        method="ignore_nearby_parameter",
+        min_value=0,
+        label="Search radius in kilometers (0 or more). Must be sent together "
+        "with lat and lon.",
+    )
     kind = django_filters.ChoiceFilter(
         choices=constants.KIND_CHOICES,
         method="filter_kind",
@@ -53,8 +97,32 @@ class PriceFilter(django_filters.FilterSet):
             return queryset.has_kind_consumption()
         return queryset
 
+    def ignore_nearby_parameter(self, queryset, name, value):
+        """Validate nearby parameters without applying them separately."""
+        return queryset
+
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        nearby_parameters = {
+            name: self.form.cleaned_data.get(name) for name in NEARBY_PARAMETER_NAMES
+        }
+        if not all(value is not None for value in nearby_parameters.values()):
+            return queryset
+
+        nearby_location_ids = (
+            Location.objects.nearby(
+                center_lat=float(nearby_parameters["lat"]),
+                center_lon=float(nearby_parameters["lon"]),
+                radius_km=float(nearby_parameters["radius_km"]),
+            )
+            .order_by()
+            .values("id")
+        )
+        return queryset.filter(location_id__in=nearby_location_ids)
+
     class Meta:
         model = Price
+        form = PriceFilterForm
         fields = {
             "type": ["exact"],
             "product_code": ["exact", "in", "isnull"],

--- a/open_prices/api/prices/tests.py
+++ b/open_prices/api/prices/tests.py
@@ -509,6 +509,153 @@ class PriceListFilterApiTest(TestCase):
         self.assertEqual(response.data["total"], 0)
 
 
+class PriceListNearbyFilterApiTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("api:prices-list")
+        cls.CENTER_LAT = 48.0
+        cls.CENTER_LON = 2.0
+        cls.location_center = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_lat=cls.CENTER_LAT,
+            osm_lon=cls.CENTER_LON,
+        )
+        cls.location_near = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_lat=cls.CENTER_LAT + 0.01,  # ~1.3km away
+            osm_lon=cls.CENTER_LON + 0.01,
+        )
+        cls.location_far = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_lat=cls.CENTER_LAT + 0.1,  # ~13km away
+            osm_lon=cls.CENTER_LON + 0.1,
+        )
+        cls.location_without_coordinates = LocationFactory(
+            type=location_constants.TYPE_OSM,
+            osm_lat=None,
+            osm_lon=None,
+        )
+        cls.location_online = LocationFactory(type=location_constants.TYPE_ONLINE)
+
+        cls.price_center = cls.create_price_for_osm_location(
+            cls.location_center, price=10
+        )
+        cls.price_near = cls.create_price_for_osm_location(cls.location_near, price=20)
+        cls.create_price_for_osm_location(cls.location_far, price=30)
+        cls.create_price_for_osm_location(cls.location_without_coordinates, price=40)
+        PriceFactory(location_id=cls.location_online.id, price=50)
+
+    @classmethod
+    def create_price_for_osm_location(cls, location, price):
+        return PriceFactory(
+            location_id=location.id,
+            location_osm_id=location.osm_id,
+            location_osm_type=location.osm_type,
+            price=price,
+        )
+
+    def test_price_list_filter_by_nearby_location(self):
+        response = self.client.get(
+            self.url,
+            {"lat": self.CENTER_LAT, "lon": self.CENTER_LON, "radius_km": 5},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 2)
+        self.assertEqual(
+            {item["id"] for item in response.data["items"]},
+            {self.price_center.id, self.price_near.id},
+        )
+
+    def test_price_list_nearby_filter_combines_with_other_filters(self):
+        response = self.client.get(
+            self.url,
+            {
+                "lat": self.CENTER_LAT,
+                "lon": self.CENTER_LON,
+                "radius_km": 5,
+                "price__gte": 15,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["id"], self.price_near.id)
+
+    def test_price_list_nearby_filter_requires_all_parameters(self):
+        parameter_sets = [
+            {"lat": self.CENTER_LAT},
+            {"lon": self.CENTER_LON},
+            {"radius_km": 5},
+            {"lat": self.CENTER_LAT, "lon": self.CENTER_LON},
+            {"lat": self.CENTER_LAT, "radius_km": 5},
+            {"lon": self.CENTER_LON, "radius_km": 5},
+        ]
+        for parameters in parameter_sets:
+            with self.subTest(parameters=parameters):
+                response = self.client.get(self.url, parameters)
+                self.assertEqual(response.status_code, 400)
+
+    def test_price_list_nearby_filter_validates_parameters(self):
+        parameter_sets = [
+            {"lat": "invalid", "lon": self.CENTER_LON, "radius_km": 5},
+            {"lat": 91, "lon": self.CENTER_LON, "radius_km": 5},
+            {"lat": self.CENTER_LAT, "lon": 181, "radius_km": 5},
+            {"lat": self.CENTER_LAT, "lon": self.CENTER_LON, "radius_km": -1},
+            {"lat": "", "lon": "", "radius_km": ""},
+        ]
+        for parameters in parameter_sets:
+            with self.subTest(parameters=parameters):
+                response = self.client.get(self.url, parameters)
+                self.assertEqual(response.status_code, 400)
+
+    def test_price_list_nearby_filter_with_zero_radius(self):
+        response = self.client.get(
+            self.url,
+            {"lat": self.CENTER_LAT, "lon": self.CENTER_LON, "radius_km": 0},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["total"], 1)
+        self.assertEqual(response.data["items"][0]["id"], self.price_center.id)
+
+    def test_price_list_nearby_filter_with_a_large_radius(self):
+        response = self.client.get(
+            self.url,
+            {"lat": self.CENTER_LAT, "lon": self.CENTER_LON, "radius_km": 1000},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        # the online location & the one without coordinates stay excluded
+        self.assertEqual(response.data["total"], 3)
+
+    def test_price_stats_uses_the_nearby_filter(self):
+        # /stats runs the same filter_queryset, so it narrows down as well
+        url = reverse("api:prices-stats")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["price__count"], 5)
+
+        response = self.client.get(
+            url,
+            {"lat": self.CENTER_LAT, "lon": self.CENTER_LON, "radius_km": 5},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        # the whole aggregate is computed on the filtered queryset, not the count alone
+        self.assertEqual(response.data["price__count"], 2)
+        self.assertEqual(response.data["price__min"], self.price_center.price)
+        self.assertEqual(response.data["price__max"], self.price_near.price)
+
+    def test_price_stats_nearby_filter_requires_all_parameters(self):
+        response = self.client.get(
+            reverse("api:prices-stats"), {"lat": self.CENTER_LAT}
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+
 class PriceDetailApiTest(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
Closes #277, open since April 2024 and labelled `top issue`.

`GET /prices` now accepts `lat`, `lon` and `radius_km`. It returns only the prices whose location sits inside that radius.

> A second PR follows on `open-prices-frontend`: openfoodfacts/open-prices-frontend#2332. It adds a "nearby" filter to the price list and to product pages, and it needs this endpoint. It stays a draft until this one is merged and deployed.

### Why I did not do this from the client

Since #1303 added `/locations/nearby`, a client can try to combine the two endpoints: fetch the nearby locations, collect their ids, then call `GET /prices?location_id__in=<ids>`. I built exactly that in the frontend. It does not hold up.

**The URL gets too long.** Measured on production, with the params the app really sends:

| Search | Locations | Request line | Result |
|---|---|---|---|
| Paris, 5 km | 407 | 2 833 B | 200 |
| Paris, 10 km | 578 | 3 983 B | 200 |
| Paris, 20 km | 671 | 4 613 B | **400 — `Request Line is too large (4562 > 4094)`** |

**Most of the download is wasted.** For Paris / 10 km the client downloads 459 KB and keeps 2 491 bytes of ids, so 0.5 % of it. `/locations/nearby` returns 26 fields per location when only `id` is needed, and `size` is capped at 100.

**Loading the locations in batches does not help either.** `order_by` would then apply inside each batch instead of the whole result. On Paris / 10 km sorted by `-created`, the 10 most recent prices of the area all come from locations outside the 20 nearest ones. The list would start one month in the past, then jump forward while the user scrolls. And the total would show 833 instead of 78 042.

### How it works

`PriceFilter.filter_queryset()` runs a subquery on the existing `Location.objects.nearby()`, so `/prices` and `/locations/nearby` share one definition of "nearby". `filters.py` imports `Location` for that.

`lat`, `lon` and `radius_km` are declared as regular filters, so they show up in the OpenAPI schema with their bounds, but they do not filter on their own: a form-level `clean()` requires the three to be sent together, otherwise the request is rejected with a 400.

That check matters more than it looks. django-filter ignores unknown params, so today `GET /prices?lat=48.85&lon=2.35&radius_km=5` returns 200 with every price, exactly like a request carrying a random param name. Sending `?lat=48.85` alone behaves the same way. Any client that guesses the param names gets a full unfiltered list instead of an error. That is the trap I fell into, and I only caught it late. The labels now say the three go together, so the generated docs show it too.

### It also reaches /prices/stats

`/prices/stats` runs the same `filter_queryset`, so it narrows down as well, and the whole aggregate is computed on the nearby subset. On my local copy of the production data, Paris / 5 km gives `price__count: 21540`, matching the list endpoint. This comes for free and looks useful, so I covered it with tests rather than leave it undocumented.

### Tests

The suite passes. Note that 4 tests around challenges and user badges currently fail on `main` too, independently of this PR — they look date-sensitive and started failing when the date rolled over. I checked by stashing my changes and running them again on a clean tree.

I also loaded the production dumps into a local database (6 783 locations, 114 869 proofs, 290 792 prices) and compared the endpoint against a haversine computed separately over the raw JSONL. 4 cities, 4 radii, **16 exact matches out of 16**:

| | 1 km | 5 km | 20 km | 100 km |
|---|---|---|---|---|
| Paris | 1 214 | 21 540 | 79 545 | 80 078 |
| Lyon | 570 | 11 795 | 16 293 | 63 719 |
| Berlin | 24 | 311 | 1 756 | 4 875 |
| Marseille | 11 | 175 | 202 | 893 |

I checked pagination over the 13 pages of Paris / 1 km: 1 214 distinct ids, no duplicate, `-created` order kept. Combining with `price__gte`, `currency`, `type` and `date__gte` gives a strict subset every time.

**It is faster than the unfiltered query**, on 290 792 prices: 23 ms at 1 km, 81 ms at 5 km, 218 ms at 20 km, against 228 ms with no filter. Even a radius large enough to cover the whole planet answers in ~75 ms for the first page. So there is no need for a maximum radius, and no need for an index on `(osm_lat, osm_lon)` at this table size.

### Possible follow-ups, not in this PR

- **Sorting by distance**, as discussed in review. It works and costs ~55 ms at 5 km, but the distance belongs to the location, not to the price: in Paris within 5 km, 21 540 prices sit on 407 locations, so about 53 prices share each distance value. I would add it as an `order_by=distance` option rather than as the default.
- **The antimeridian.** `Location.objects.nearby()` compares `osm_lon` to `center_lon ± delta` without wrapping at ±180°, so a location at 179.9° and one at −179.9° are about 22 km apart but never match each other. I reproduced it on both sides, and the same longitude gap around 0° works fine. It comes from #1303 and is not introduced here. There is no data in that area today.

### Note for reviewers

`manage.py makemigrations --check` already fails on `main`: `PriceStatistics5y` in `prices/models.py` has no migration. This PR does not touch any model, so that failure does not come from it.

### Two things I found in the published dumps

- 4 proofs have a **negative `price_count`**, down to −9. The schema itself rejects this, since the column is a `PositiveIntegerField`. It looks like a counter going below zero when prices are deleted.
- There is no `products.jsonl.gz` (404), so `product_id` cannot be restored from the dumps.
