### PR TITLE
fix: re-normalize price category tags when the taxonomy renames a canonical id

### DIFF
--- a/open_prices/common/tasks.py
+++ b/open_prices/common/tasks.py
@@ -74,6 +74,10 @@ def update_location_counts_task():
     Location.update_task()
 
 
+def update_price_category_tag_task():
+    Price.update_task()
+
+
 def update_challenge_task():
     Challenge.update_task()
 
@@ -153,6 +157,7 @@ CRON_SCHEDULES = {
     "update_user_counts_task": ("0 2 * * *", {}),  # daily at 02:00
     "update_badge_task": ("5 2 * * *", {}),  # daily at 02:05
     "update_total_stats_task": ("10 2 * * *", {}),  # daily at 02:10
+    "update_price_category_tag_task": ("40 2 * * *", {}),  # daily at 02:40
     "update_location_counts_task": (
         "20 2 * * 1",  # every start of the week (at 02:20)
         {},

--- a/open_prices/prices/models.py
+++ b/open_prices/prices/models.py
@@ -16,6 +16,7 @@ from open_prices.challenges.models import Challenge
 from open_prices.common import (
     constants,
     history,
+    openfoodfacts,
     utils,
 )
 from open_prices.locations import constants as location_constants
@@ -351,6 +352,24 @@ class Price(models.Model):
         self.set_location()
         self.set_is_duplicate_of()
         super().save(*args, **kwargs)
+
+    @classmethod
+    def update_task(cls):
+        """
+        - Update category_tag to the current canonical taxonomy id, in case
+          it was renamed upstream since the price was created (see #1338)
+        """
+        for price in cls.objects.has_type_category():
+            price.update_category_tag()
+
+    def update_category_tag(self):
+        normalized_category_tag = openfoodfacts.normalize_taxonomized_tags(
+            "category", [self.category_tag]
+        )[0]
+        if normalized_category_tag != self.category_tag:
+            self.category_tag = normalized_category_tag
+            self._change_reason = "Price.update_category_tag() method"
+            self.save(update_fields=["category_tag"])
 
     def set_tag(self, tag: str, save: bool = True):
         if tag not in self.tags:

--- a/open_prices/prices/tests.py
+++ b/open_prices/prices/tests.py
@@ -1078,6 +1078,67 @@ class PriceModelUpdateTest(TestCase):
         self.assertEqual(self.price.product, product_8001505005707)
 
 
+class PriceModelUpdateCategoryTagTest(TestCase):
+    """
+    Covers https://github.com/openfoodfacts/open-prices/issues/1338:
+    `category_tag` is only normalized to the taxonomy's canonical id once,
+    at creation time. When Open Food Facts renames a category's canonical id
+    (e.g. "en:kiwis" -> "en:kiwifruits"), prices already stored under the
+    old id should get merged with prices using the new one.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        # bulk_create to skip save() & clean(), simulating prices stored
+        # under a category id that was canonical at creation time but has
+        # since been renamed upstream
+        Price.objects.bulk_create(
+            [
+                PriceFactory.build(
+                    type=price_constants.TYPE_CATEGORY,
+                    category_tag="en:kiwis",  # stale, renamed to "en:kiwifruits"
+                    price_per=price_constants.PRICE_PER_KILOGRAM,
+                ),
+                PriceFactory.build(
+                    type=price_constants.TYPE_CATEGORY,
+                    category_tag="en:kiwifruits",  # already canonical
+                    price_per=price_constants.PRICE_PER_KILOGRAM,
+                ),
+                PriceFactory.build(
+                    type=price_constants.TYPE_CATEGORY,
+                    category_tag="en:mandarin-oranges",  # stale, renamed to "en:mandarins"
+                    price_per=price_constants.PRICE_PER_KILOGRAM,
+                ),
+            ]
+        )
+
+    def test_update_category_tag(self):
+        price = Price.objects.get(category_tag="en:kiwis")
+        price.update_category_tag()
+        self.assertEqual(price.category_tag, "en:kiwifruits")
+        price.refresh_from_db()
+        self.assertEqual(price.category_tag, "en:kiwifruits")
+
+    def test_update_category_tag_already_canonical(self):
+        # no-op, and no extra save() call, if already canonical
+        price = Price.objects.get(category_tag="en:kiwifruits")
+        price.update_category_tag()
+        self.assertEqual(price.category_tag, "en:kiwifruits")
+
+    def test_update_task_classmethod(self):
+        self.assertEqual(Price.objects.count(), 3)
+        Price.update_task()
+        # the two kiwi prices now share the current canonical category tag
+        self.assertEqual(
+            Price.objects.filter(category_tag="en:kiwifruits").count(), 2
+        )
+        # the mandarin price was independently normalized to its own
+        # canonical tag
+        self.assertEqual(
+            Price.objects.filter(category_tag="en:mandarins").count(), 1
+        )
+
+
 class PriceModelDeleteTest(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
Fixes #1338. Related to #1398 (already fixed separately, on https://github.com/openfoodfacts/open-prices/pull/1425).

`Price.category_tag` is only normalized to the taxonomy's canonical id once,
at creation time. When Open Food Facts renames a category's canonical id
(e.g. `en:kiwis` -> `en:kiwifruits`), old prices are never updated, so they
stop matching newer prices under the renamed id.

Adds a daily task that re-normalizes `category_tag` for all `type=category`
prices, following the existing `Model.update_task()` + `CRON_SCHEDULES`
convention (`Product`, `User`, `Location`):

- `Price.update_task()` / `Price.update_category_tag()` in `prices/models.py`
- `update_price_category_tag_task()` in `common/tasks.py`, daily at 02:40
- Tests in `PriceModelUpdateCategoryTagTest` (`prices/tests.py`)